### PR TITLE
Add ConnectionError exception

### DIFF
--- a/hpedockerplugin/exception.py
+++ b/hpedockerplugin/exception.py
@@ -143,6 +143,10 @@ class Invalid3PARDomain(PluginException):
     message = _("Invalid 3PAR Domain: %(err)s")
 
 
+class ConnectionError(PluginException):
+    message = _("Unable to connect to storage array/appliance: %(err)s")
+
+
 class InvalidInput(PluginException):
     message = _("Invalid input received: %(reason)s")
 

--- a/hpedockerplugin/hpe/hpe_lefthand_iscsi.py
+++ b/hpedockerplugin/hpe/hpe_lefthand_iscsi.py
@@ -139,10 +139,10 @@ class HPELeftHandISCSIDriver(object):
 
             return client
         except hpeexceptions.HTTPNotFound:
-            raise exception.DriverNotInitialized(
+            raise exception.ConnectionError(
                 _('LeftHand cluster not found'))
         except Exception as ex:
-            raise exception.DriverNotInitialized(ex)
+            raise exception.ConnectionError(ex)
 
     def _logout(self, client):
         client.logout()


### PR DESCRIPTION
Add a new exception to use for connection errors as opposed to
using the non-existent DriverNotInitialized exception.