### PR TITLE
Updated dependencies for alpine:edge tag for the plugin container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:edge
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONPATH=${HOME}/python-hpedockerplugin:/root/python-hpedockerplugin
@@ -12,8 +12,8 @@ RUN apk add --no-cache --update \
     multipath-tools \
     device-mapper \
     util-linux \
-    strace \
     eudev \
+    libssl1.0 \
 	sudo \
  && apk update \
  && apk upgrade \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-os-brick>=1.4.0
+os-brick==1.13.1
 python-3parclient>=4.0.0
 python-lefthandclient>=2.0.1
 sh>=1.11
+eventlet==0.18.2
 six>=1.10.0
 python-etcd>=0.4.3
 oslo.versionedobjects>=1.3.0


### PR DESCRIPTION
the alpine container is updated with "edge" tag , so as to avoid security vulnerabilities around sudo,musl libraries. Done as part of Docker store Certification.