### PR TITLE
Fix problem with multiple etcd cluster in unsecure mode

### DIFF
--- a/hpedockerplugin/etcdutil.py
+++ b/hpedockerplugin/etcdutil.py
@@ -59,7 +59,9 @@ class EtcdUtil(object):
         else:
             LOG.info('ETCDUTIL no certs')
             if len(host_tuple) > 0:
-               self.client = etcd.Client(host=host_tuple, port=port)
+               LOG.info('Use http protocol')
+               self.client = etcd.Client(host=host_tuple, port=port,
+                              protocol='http', allow_reconnect=True)
             else:
                self.client = etcd.Client(host, port)
         self._make_root()


### PR DESCRIPTION
Fix problem with etcd client creation with multiple etcd cluster members in unsecure mode
stack@worker1:~$ docker plugin enable hpe
Error response from daemon: dial unix /run/docker/plugins/cd5d714d44cb87f39926b1ff20d0f96e9c5ac53e846c93f12f83ab179bb34b4f/hpe.sock: connect: no such file or directory
 
Aug  8 05:22:13 worker1 dockerd[11151]: time="2017-08-08T05:22:13-07:00" level=info msg="2017-08-08 12:22:13.497 22 ERROR etcd.client [-] List of hosts incompatible with allow_reconnect." plugin=cd5d714d44cb87f39926b1ff20d0f96e9c5ac53e846c93f12f83ab179bb34b4f
Aug  8 05:22:13 worker1 dockerd[11151]: time="2017-08-08T05:22:13-07:00" level=info msg="2017-08-08 12:22:13.498 22 ERROR hpe_storage_api   File \"/usr/lib/python2.7/site-packages/etcd/client.py\", line 139, in __init__" plugin=cd5d714d44cb87f39926b1ff20d0f96e9c5ac53e846c93f12f83ab179bb34b4f
Aug  8 05:22:13 worker1 dockerd[11151]: time="2017-08-08T05:22:13-07:00" level=info msg="2017-08-08 12:22:13.498 22 ERROR hpe_storage_api     raise etcd.EtcdException(\"A list of hosts to connect to was given, but reconnection not allowed?\")" plugin=cd5d714d44cb87f39926b1ff20d0f96e9c5ac53e846c93f12f83ab179bb34b4f
Aug  8 05:22:13 worker1 dockerd[11151]: time="2017-08-08T05:22:13-07:00" level=info msg="2017-08-08 12:22:13.498 22 ERROR hpe_storage_api EtcdException: A list of hosts to connect to was given, but reconnection not allowed?" plugin=cd5d714d44cb87f39926b1ff20d0f96e9c5ac53e846c93f12f83ab179bb34b4f
Aug  8 05:22:13 worker1 dockerd[11151]: time="2017-08-08T05:22:13-07:00" level=info msg="2017-08-08 12:22:13.498 22 ERROR hpe_storage_api " plugin=cd5d714d44cb87f39926b1ff20d0f96e9c5ac53e846c93f12f83ab179bb34b4f
 