### PR TITLE
Override the values of use_multipath, enforce_multipath to True in case of FC Driver

### DIFF
--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -101,8 +101,19 @@ class VolumePlugin(object):
         # TODO: make device_scan_attempts configurable
         # see nova/virt/libvirt/volume/iscsi.py
         root_helper = 'sudo'
-        self.use_multipath = self._hpepluginconfig.use_multipath
-        self.enforce_multipath = self._hpepluginconfig.enforce_multipath
+         
+        # Override the settings of use_multipath, enforce_multipath
+        # in case of FC Driver for 3PAR
+        # This will be a workaround until Issue #50 is fixed.
+        if 'HPE3PARFCDriver' in hpeplugin_driver:
+          msg = (_('Overriding the value of multipath flags to True'))
+          LOG.info(msg)
+          self.use_multipath = True
+          self.enforce_multipath = True
+        else:
+          self.use_multipath = self._hpepluginconfig.use_multipath
+          self.enforce_multipath = self._hpepluginconfig.enforce_multipath
+
         self.connector = connector.InitiatorConnector.factory(
             protocol, root_helper, use_multipath=self.use_multipath,
             device_scan_attempts=5, transport='default')

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pbr==2.0.0
 klein==17.2.0
 pycrypto
 pyasn1==0.2.3
+pika==0.10.0


### PR DESCRIPTION
Issue #50 is due to the incorrect default value of False for configuration parameters use_multipath, enforce_multipath both being set to False.

This change overrides the value to True irrespective of whatever set in hpe.conf only for FC Driver.
Please note: iSCSI Driver is unaffected by this change , and it can operate with both multipath and single path.