### PR TITLE
Feature: Adding compression feature for ISCSI, FC driver and pep8 cha…

### DIFF
--- a/hpedockerplugin/hpe/hpe_3par_common.py
+++ b/hpedockerplugin/hpe/hpe_3par_common.py
@@ -36,6 +36,7 @@ LOG = logging.getLogger(__name__)
 MIN_CLIENT_VERSION = '4.0.0'
 DEDUP_API_VERSION = 30201120
 FLASH_CACHE_API_VERSION = 30201200
+COMPRESSION_API_VERSION = 30301215
 
 hpe3par_opts = [
     cfg.StrOpt('hpe3par_api_url',
@@ -101,10 +102,11 @@ class HPE3PARCommon(object):
         0.0.1 - Initial version of 3PAR common created.
         0.0.2 - Added the ability to choose volume provisionings.
         0.0.3 - Added support for flash cache.
+        0.0.4 - Added support for compression CRUD operation.
 
     """
 
-    VERSION = "0.0.3"
+    VERSION = "0.0.4"
 
     # TODO(Ramy): move these to the 3PAR Client
     VLUN_TYPE_EMPTY = 1
@@ -118,6 +120,9 @@ class HPE3PARCommon(object):
     CONVERT_TO_THIN = 1
     CONVERT_TO_FULL = 2
     CONVERT_TO_DEDUP = 3
+
+    # License values for reported capabilities
+    COMPRESSION_LIC = "Compression"
 
     # Valid values for volume type extra specs
     # The first value in the list is the default value
@@ -502,6 +507,24 @@ class HPE3PARCommon(object):
         else:
             return default
 
+    def _check_license_enabled(self, valid_licenses, license_to_check,
+                               capability):
+        """Check a license against valid licenses on the array."""
+
+        LOG.info(_LI(" license_to_check and valid_licenses are"
+                     " '%(license_to_check)s' \n  '%(valid_licenses)s' "),
+                 {'license_to_check': license_to_check,
+                  'valid_licenses': valid_licenses})
+        if valid_licenses:
+            for license in valid_licenses:
+                if license_to_check in license.get('name'):
+                    return True
+            LOG.debug(("'%(capability)s' requires a '%(license)s' "
+                       "license which is not installed.") %
+                      {'capability': capability,
+                       'license': license_to_check})
+        return False
+
     def _get_keys_by_volume_type(self, volume_type):
         hpe3par_keys = {}
         specs = volume_type.get('extra_specs')
@@ -526,6 +549,35 @@ class HPE3PARCommon(object):
         vol = self.client.getVolume(volume_name)
         if 'comment' in vol:
             return vol['comment']
+        return None
+
+    def get_compression_policy(self, compression_val):
+        compression_support = False
+        info = self.client.getStorageSystemInfo()
+        if 'licenseInfo' in info:
+            if 'licenses' in info['licenseInfo']:
+                valid_licenses = info['licenseInfo']['licenses']
+                compression_support = self._check_license_enabled(
+                    valid_licenses, self.COMPRESSION_LIC, "Compression")
+            # here check the WSAPI version
+        if self.API_VERSION < COMPRESSION_API_VERSION:
+            err = (_("Compression policy requires "
+                     "WSAPI version '%(compression_version)s' "
+                     "version '%(version)s' is installed.") %
+                   {'compression_version': COMPRESSION_API_VERSION,
+                    'version': self.self.API_VERSION})
+            LOG.error(err)
+            raise exception.InvalidInput(reason=err)
+        else:
+            if compression_val.lower() == 'true':
+                if not compression_support:
+                    msg = _('Compression is not supported on '
+                            'underlying hardware')
+                    LOG.error(msg)
+                    raise exception.InvalidInput(reason=msg)
+                return True
+            else:
+                return False
         return None
 
     def create_volume(self, volume):
@@ -560,6 +612,8 @@ class HPE3PARCommon(object):
 
             tpvv = True
             tdvv = False
+            fullprovision = False
+            compression = None
 
             if prov_value == "full":
                 tpvv = False
@@ -584,6 +638,30 @@ class HPE3PARCommon(object):
                 extras['tdvv'] = tdvv
 
             capacity = self._capacity_from_size(volume['size'])
+
+            if (tpvv is False and tdvv is False):
+                fullprovision = True
+
+            compression_val = volume['compression']   # None/true/False
+            compression = None
+
+            if compression_val is not None:
+                compression = self.get_compression_policy(compression_val)
+
+            if compression is True:
+                if not fullprovision and capacity >= 16384:
+                    extras['compression'] = compression
+                else:
+                    err = (_("To create compression enabled volume, size of "
+                             "the volume should be atleast 16GB. Fully "
+                             "provisioned volume can not be compressed. "
+                             "Please re enter requested volume size or "
+                             "provisioning type. "))
+                    LOG.error(err)
+                    raise exception.InvalidInput(reason=err)
+            if compression is not None:
+                extras['compression'] = compression
+
             volume_name = self._get_3par_vol_name(volume['id'])
             self.client.createVolume(volume_name, cpg, capacity, extras)
 

--- a/hpedockerplugin/hpe/volume.py
+++ b/hpedockerplugin/hpe/volume.py
@@ -12,9 +12,10 @@ volume['volume_type'] = ''
 volume['volume_attachment'] = ''
 volume['provisioning'] = ''
 volume['flash_cache'] = ''
+volume['compression'] = ''
 
 
-def createvol(name, uuid, size, prov, flash_cache):
+def createvol(name, uuid, size, prov, flash_cache, compression_val):
     volume['id'] = uuid
     volume['name'] = uuid
     volume['host'] = ''
@@ -30,5 +31,6 @@ def createvol(name, uuid, size, prov, flash_cache):
     volume['path_info'] = None
     volume['provisioning'] = prov
     volume['flash_cache'] = flash_cache
+    volume['compression'] = compression_val
 
     return volume

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -43,6 +43,7 @@ DEFAULT_SIZE = 100
 DEFAULT_PROV = "thin"
 DEFAULT_FLASH_CACHE = None
 DEFAULT_MOUNT_VOLUME = "True"
+DEFAULT_COMPRESSION_VAL = None
 
 LOG = logging.getLogger(__name__)
 
@@ -330,8 +331,11 @@ class VolumePlugin(object):
         volname = contents['Name']
 
         # Verify valid Opts arguments.
-        valid_volume_create_opts = ['mount-volume',
+        valid_volume_create_opts = ['mount-volume', 'compression',
                                     'size', 'provisioning', 'flash-cache']
+
+        valid_compression_opts = ['true', 'false']
+
         if ('Opts' in contents and contents['Opts']):
             for key in contents['Opts']:
                 if key not in valid_volume_create_opts:
@@ -352,6 +356,20 @@ class VolumePlugin(object):
         if ('Opts' in contents and contents['Opts'] and
                 'provisioning' in contents['Opts']):
             vol_prov = str(contents['Opts']['provisioning'])
+
+        compression_val = DEFAULT_COMPRESSION_VAL
+        if ('Opts' in contents and contents['Opts'] and
+                'compression' in contents['Opts']):
+            compression_val = str(contents['Opts']['compression'])
+
+        if compression_val is not None:
+            if compression_val.lower() not in valid_compression_opts:
+                msg = (_('create volume failed, error is:'
+                         'passed compression parameterdo not have a valid '
+                         'value. Valid vaues are: %(valid)s') %
+                       {'valid': valid_compression_opts, })
+                LOG.error(msg)
+                return json.dumps({u"Err": six.text_type(msg)})
 
         vol_flash = DEFAULT_FLASH_CACHE
         if ('Opts' in contents and contents['Opts'] and
@@ -391,7 +409,8 @@ class VolumePlugin(object):
             return json.dumps({u"Err": ''})
 
         voluuid = str(uuid.uuid4())
-        vol = volume.createvol(volname, voluuid, vol_size, vol_prov, vol_flash)
+        vol = volume.createvol(volname, voluuid, vol_size, vol_prov,
+                               vol_flash, compression_val)
 
         try:
             self.hpeplugin_driver.create_volume(vol)

--- a/test/test_hpe_plugin.py
+++ b/test/test_hpe_plugin.py
@@ -143,7 +143,7 @@ class HPEPLUGINTESTS(unittest.TestCase):
         bashcommand = "/usr/bin/twistd hpe_plugin_service"
         try:
             subprocess.check_output(['sh', '-c', bashcommand], cwd=TEST_DIR)
-        except:
+        except Exception:
             LOG.error("Test Setup Failed: Could not change dir")
             self.fail(msg='Test Failed')
 


### PR DESCRIPTION
# Command to create thinly provisioned compressed volume :

`docker volume create -d hpe --name compvolume1 -o size=16 -o compression=true -o provisioning=thin`

Above hpe is the alias name for HPE volume plugin

`Note:`
1. For a volume to be compression enabled minimum size of the volume should be 16 GB
2. Only thin and dedup volumes can be enabled for compression
3. If size of the volume is less than 16 GB or provisioning type is full and compression parameter is passed as a true (-o compression=true) , volume creation will fail
4. Valid compression options are true/false or True/False (Not case sensitive)
5. Compression is supported on 8k series and 20k series array of 3PAR and requires minimum WSAPI version of 1.6 and needs Real Madrid OS(3.3.1.215 or more) on 3PAR
6. For enabling comperssion SSD disks are needed
