### PR TITLE
Fix for issue #83 -- Add retry for mkfs command 

### DIFF
--- a/buildDockerPlugin.sh
+++ b/buildDockerPlugin.sh
@@ -44,7 +44,8 @@ mkdir v2plugin > /dev/null 2>&1
 rm -rf v2plugin/rootfs
 
 ./containerize.sh
-docker tag $REPO_NAME/python-hpedockerplugin:plugin_v2 $1
+BRANCH_NAME=`git branch | grep "^*" | cut -d' ' -f2`
+docker tag $REPO_NAME/python-hpedockerplugin:$BRANCH_NAME $1
 rc=$?
  if [[ $rc -ne 0 ]]; then
   echo "ERROR: failed"

--- a/hpedockerplugin/fileutil.py
+++ b/hpedockerplugin/fileutil.py
@@ -25,6 +25,7 @@ import exception
 import six
 
 from twisted.python.filepath import FilePath
+from retrying import retry
 
 LOG = logging.getLogger(__name__)
 
@@ -43,6 +44,14 @@ def has_filesystem(path):
     return True
 
 
+def retry_if_io_error(exception1):
+    LOG.info("Retry attempted on mkfs due to exception")
+    return isinstance(exception1, exception.HPEPluginFileSystemException)
+
+
+@retry(retry_on_exception=retry_if_io_error,
+       stop_max_attempt_number=3,
+       wait_fixed=2000)
 def create_filesystem(path):
     try:
         # Create filesystem without user intervention, -F

--- a/hpedockerplugin/fileutil.py
+++ b/hpedockerplugin/fileutil.py
@@ -51,7 +51,7 @@ def retry_if_io_error(exception1):
 
 @retry(retry_on_exception=retry_if_io_error,
        stop_max_attempt_number=3,
-       wait_fixed=2000)
+       wait_fixed=20000)
 def create_filesystem(path):
     try:
         # Create filesystem without user intervention, -F

--- a/test/test_fileutil.py
+++ b/test/test_fileutil.py
@@ -1,10 +1,11 @@
 from hpedockerplugin import fileutil
 import mock
 from testtools import TestCase
-
+import time
 
 class TestFileSystemCreationFailureWithRetry(TestCase):
-    def test_retry_on_create_filesystem():
+    def test_retry_on_create_filesystem(self):
+        start_time = time.time()
         with mock.patch.object(fileutil, 'mkfs') as mock_mkfs:
             mock_mkfs.side_effect = \
                 [Exception("ex1"),
@@ -13,6 +14,8 @@ class TestFileSystemCreationFailureWithRetry(TestCase):
         try:
             fileutil.create_filesystem("/dev/sde")
         except Exception as ex:
-            super.assertEqual(len(mock_mkfs.mock_calls),
-                              len(mock_mkfs.side_effect))
             print ex.message
+        finally:
+            end_time = time.time()
+            print 'Duration : %d ' % (end_time - start_time)
+            self.assertTrue((end_time - start_time) >= 40)

--- a/test/test_fileutil.py
+++ b/test/test_fileutil.py
@@ -1,0 +1,18 @@
+from hpedockerplugin import fileutil
+import mock
+from testtools import TestCase
+
+
+class TestFileSystemCreationFailureWithRetry(TestCase):
+    def test_retry_on_create_filesystem():
+        with mock.patch.object(fileutil, 'mkfs') as mock_mkfs:
+            mock_mkfs.side_effect = \
+                [Exception("ex1"),
+                 Exception("ex2"),
+                 Exception("ex3")]
+        try:
+            fileutil.create_filesystem("/dev/sde")
+        except Exception as ex:
+            super.assertEqual(len(mock_mkfs.mock_calls),
+                              len(mock_mkfs.side_effect))
+            print ex.message

--- a/test/test_hpe_plugin.py
+++ b/test/test_hpe_plugin.py
@@ -143,7 +143,7 @@ class HPEPLUGINTESTS(unittest.TestCase):
         bashcommand = "/usr/bin/twistd hpe_plugin_service"
         try:
             subprocess.check_output(['sh', '-c', bashcommand], cwd=TEST_DIR)
-        except:
+        except Exception:
             LOG.error("Test Setup Failed: Could not change dir")
             self.fail(msg='Test Failed')
 


### PR DESCRIPTION
Once in a while we noticed in CHO runs , the mkfs -F /dev/sd? command (filesystem creation command) for the presented raw device on the initiator host fails with an error as indicated in the issue #83 

Fix is done for attempting retry on this same operation with a fixed delay of 20 secs, between iterations for 3 times.