### PR TITLE
Fix for issue88

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache --update \
 	sudo \
  && apk update \
  && apk upgrade \
- && apk add e2fsprogs ca-certificates wget \ 
+ && apk add e2fsprogs ca-certificates \ 
  && pip install --upgrade pip \
     setuptools \
  && rm -rf /var/cache/apk/*
@@ -40,14 +40,6 @@ RUN apk add --virtual /tmp/.temp --no-cache --update \
 	openssl-dev \
     python-dev \
 
-# Need different version of pyasn1 for iscsi to work properly
-# && wget https://pypi.python.org/packages/6a/cc/5878c5f2e5043a526653ca61885e65ee834847ed3933545e31a96ecaa40d/pyasn1-0.2.1.tar.gz#md5=9dfafed199b321d56bab9cd341b6dd01 \
-# && wget https://pypi.python.org/packages/69/17/eec927b7604d2663fef82204578a0056e11e0fc08d485fdb3b6199d9b590/pyasn1-0.2.3.tar.gz#md5=79f98135071c8dd5c37b6c923c51be45 \
-# && wget http://10.50.177.1:8088/tmp/pyasn1-0.1.9.tar.gz \
-# && tar xvzf pyasn1-0.2.3.tar.gz \
-# && cd pyasn1-0.2.3 \
-# && python setup.py install \
-# && rm -rf pyasn1-0.2.3 \
 
 # build and install hpedockerplugin
  && cd /python-hpedockerplugin \

--- a/buildDockerPlugin.sh
+++ b/buildDockerPlugin.sh
@@ -44,7 +44,8 @@ mkdir v2plugin > /dev/null 2>&1
 rm -rf v2plugin/rootfs
 
 ./containerize.sh
-docker tag $REPO_NAME/python-hpedockerplugin:plugin_v2 $1
+BRANCH_NAME=`git branch | grep "^*" | cut -d' ' -f2`
+docker tag $REPO_NAME/python-hpedockerplugin:$BRANCH_NAME $1
 rc=$?
  if [[ $rc -ne 0 ]]; then
   echo "ERROR: failed"

--- a/hpedockerplugin/fileutil.py
+++ b/hpedockerplugin/fileutil.py
@@ -25,6 +25,7 @@ import exception
 import six
 
 from twisted.python.filepath import FilePath
+from retrying import retry
 
 LOG = logging.getLogger(__name__)
 
@@ -43,6 +44,14 @@ def has_filesystem(path):
     return True
 
 
+def retry_if_io_error(exception1):
+    LOG.info("Retry attempted on mkfs due to exception")
+    return isinstance(exception1, exception.HPEPluginFileSystemException)
+
+
+@retry(retry_on_exception=retry_if_io_error,
+       stop_max_attempt_number=3,
+       wait_fixed=20000)
 def create_filesystem(path):
     try:
         # Create filesystem without user intervention, -F

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -199,7 +199,6 @@ class VolumePlugin(object):
                            'snapshots - volume cannot be deleted!'
                            % volname))
                 LOG.error(msg)
-                # raise exception.HPEPluginRemoveException(reason=msg)
                 response = json.dumps({u"Err": msg})
                 try:
                     self._etcd.try_unlock_volname(volname)
@@ -207,7 +206,6 @@ class VolumePlugin(object):
                     LOG.error('volume: %(name)s Unlock volume failed',
                               {'name':volname})
                     response = json.dumps({u"Err": six.text_type(ex)})
-                    return response
                 return response
             else:
                 self.hpeplugin_driver.delete_volume(vol)
@@ -226,7 +224,6 @@ class VolumePlugin(object):
                           {'name': volname})
                 response = json.dumps({u"Err": six.text_type(ex)})
                 return response
-#            raise exception.HPEPluginRemoveException(reason=msg)            
             return json.dumps({u"Err": six.text_type(ex)})
 
         try:
@@ -312,7 +309,6 @@ class VolumePlugin(object):
                             LOG.error('volume: %(name)s Unlock Volume Failed',
                                       {'name': volname})
                             response = json.dumps({u"Err": six.text_type(ex)})
-                            return response
                         return response
 
                     LOG.info("Deleting snapshot in ETCD - %s" % snapname)

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -257,10 +257,12 @@ class VolumePlugin(object):
         return None, None
 
     def volumedriver_remove_snapshot(self, volname, snapname):
+        lock_acquired = False
         try:
             LOG.info("volumedriver_remove_snapshot - locking volume %s"
                      % volname)
             self._etcd.try_lock_volname(volname)
+            lock_acquired = True
 
             LOG.info("volumedriver_remove_snapshot - getting volume %s"
                      % volname)
@@ -299,13 +301,13 @@ class VolumePlugin(object):
                         self.hpeplugin_driver.delete_volume(snapshot,
                                                             is_snapshot=True)
                     except Exception as err:
-                        msg = (_LE('Failed to remove snapshot %s ,error is %s'),
-                               snapname, six.text_type(err))
+                        msg = (_LE('Failed to remove snapshot error is: %s'),
+                               six.text_type(err))
                         LOG.error(msg)
-                        response = json.dumps({u"Err": msg})
+                        response = json.dumps({u"Err": six.text_type(err)})
                         try:
                             self._etcd.try_unlock_volname(volname)
-                            lock_aquired = False
+                            lock_acquired = False
                         except Exception as ex:
                             LOG.error('volume: %(name)s Unlock Volume Failed',
                                       {'name': volname})

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -201,6 +201,13 @@ class VolumePlugin(object):
                 LOG.error(msg)
                 # raise exception.HPEPluginRemoveException(reason=msg)
                 response = json.dumps({u"Err": msg})
+                try:
+                    self._etcd.try_unlock_volname(volname)
+                except Exception as ex:
+                    LOG.error('volume: %(name)s Unlock volume failed',
+                              {'name':volname})
+                    response = json.dumps({u"Err": six.text_type(ex)})
+                    return response
                 return response
             else:
                 self.hpeplugin_driver.delete_volume(vol)
@@ -219,7 +226,8 @@ class VolumePlugin(object):
                           {'name': volname})
                 response = json.dumps({u"Err": six.text_type(ex)})
                 return response
-            raise exception.HPEPluginRemoveException(reason=msg)
+#            raise exception.HPEPluginRemoveException(reason=msg)            
+            return json.dumps({u"Err": six.text_type(ex)})
 
         try:
             self._etcd.delete_vol(vol)
@@ -286,9 +294,24 @@ class VolumePlugin(object):
                             # reason=msg)
                             response = json.dumps({u"Err": msg})
                             return response
-                    LOG.info("Deleting snapshot at backend: %s" % snapname)
-                    self.hpeplugin_driver.delete_volume(snapshot,
-                                                        is_snapshot=True)
+                    try:
+                        LOG.info("Deleting snapshot at backend: %s" % snapname)
+                        self.hpeplugin_driver.delete_volume(snapshot,
+                                                            is_snapshot=True)
+                    except Exception as err:
+                        msg = (_LE('Failed to remove snapshot %s ,error is %s'),
+                               snapname, six.text_type(err))
+                        LOG.error(msg)
+                        response = json.dumps({u"Err": msg})
+                        try:
+                            self._etcd.try_unlock_volname(volname)
+                            lock_aquired = False
+                        except Exception as ex:
+                            LOG.error('volume: %(name)s Unlock Volume Failed',
+                                      {'name': volname})
+                            response = json.dumps({u"Err": six.text_type(ex)})
+                            return response
+                        return response
 
                     LOG.info("Deleting snapshot in ETCD - %s" % snapname)
                     # Remove snapshot entry from list and save it back to
@@ -329,7 +352,8 @@ class VolumePlugin(object):
             # Expand lock code inline as function based lock causes
             # unexpected behavior
             try:
-                self._etcd.try_unlock_volname(volname)
+                if lock_acquired:
+                    self._etcd.try_unlock_volname(volname)
             except Exception as ex:
 
                 LOG.error('volume: %(name)s Unlock Volume Failed',

--- a/test/test_fileutil.py
+++ b/test/test_fileutil.py
@@ -1,0 +1,21 @@
+from hpedockerplugin import fileutil
+import mock
+from testtools import TestCase
+import time
+
+class TestFileSystemCreationFailureWithRetry(TestCase):
+    def test_retry_on_create_filesystem(self):
+        start_time = time.time()
+        with mock.patch.object(fileutil, 'mkfs') as mock_mkfs:
+            mock_mkfs.side_effect = \
+                [Exception("ex1"),
+                 Exception("ex2"),
+                 Exception("ex3")]
+        try:
+            fileutil.create_filesystem("/dev/sde")
+        except Exception as ex:
+            print ex.message
+        finally:
+            end_time = time.time()
+            print 'Duration : %d ' % (end_time - start_time)
+            self.assertTrue((end_time - start_time) >= 40)

--- a/test/test_fileutil.py
+++ b/test/test_fileutil.py
@@ -3,6 +3,7 @@ import mock
 from testtools import TestCase
 import time
 
+
 class TestFileSystemCreationFailureWithRetry(TestCase):
     def test_retry_on_create_filesystem(self):
         start_time = time.time()
@@ -14,7 +15,7 @@ class TestFileSystemCreationFailureWithRetry(TestCase):
         try:
             fileutil.create_filesystem("/dev/sde")
         except Exception as ex:
-            print ex.message
+            print ex
         finally:
             end_time = time.time()
             print 'Duration : %d ' % (end_time - start_time)


### PR DESCRIPTION
This fixes an issue #88 
Here first failure to delete the volume was not unlocking the locked volume , hence the successive delete operations were failing.
Also during the investigation I found that , when we try to delete the snapshot and due to 3PAR constraints snapshot can not be deleted, in such case error message was shown on the logs but there was no console output for the same.

This patch fixes both the issues.