### PR TITLE
Added qos support on clone volume

### DIFF
--- a/hpedockerplugin/hpe/hpe_3par_common.py
+++ b/hpedockerplugin/hpe/hpe_3par_common.py
@@ -1095,15 +1095,19 @@ class HPE3PARCommon(object):
                                   tpvv=tpvv, tdvv=tdvv,
                                   compression=compression)
 
+                # check for qos
+                vvs_name = src_vref.get('qos_name')
+
                 # Check if flash cache needs to be enabled
                 flash_cache = \
                     self.get_flash_cache_policy(src_vref['flash_cache'])
 
-                if flash_cache is not None:
+                if vvs_name or flash_cache is not None:
                     try:
                         self._add_volume_to_volume_set(dst_volume,
                                                        dst_3par_vol_name,
-                                                       cpg, flash_cache)
+                                                       cpg, flash_cache,
+                                                       vvs_name)
                     except exception.InvalidInput as ex:
                         # Delete volume if unable to add it to volume set
                         self.client.deleteVolume(dst_3par_vol_name)

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -647,7 +647,8 @@ class VolumePlugin(object):
             clone_vol = volume.createvol(clone_name, clone_vol_id, size,
                                          src_vol['provisioning'],
                                          src_vol['flash_cache'],
-                                         src_vol['compression'])
+                                         src_vol['compression'],
+                                         src_vol['qos_name'])
             try:
                 self.hpeplugin_driver.create_cloned_volume(clone_vol, src_vol)
 

--- a/test/clonevolume_tester.py
+++ b/test/clonevolume_tester.py
@@ -206,6 +206,28 @@ class TestCloneWithFlashCache(CloneVolumeUnitTest):
         mock_3parclient.getCPG.return_value = {}
 
 
+# Online copy with qos flow
+class TestCloneWithQOS(CloneVolumeUnitTest):
+    def check_response(self, resp):
+        self._test_case.assertEqual(resp, {u"Err": ''})
+
+        # Check required WSAPI calls were made
+        mock_3parclient = self.mock_objects['mock_3parclient']
+        mock_3parclient.addVolumeToVolumeSet.assert_called()
+
+    def get_request_params(self):
+        return {"Name": "clone-vol-001",
+                "Opts": {"cloneOf": data.VOLUME_NAME}}
+
+    def setup_mock_objects(self):
+        mock_etcd = self.mock_objects['mock_etcd']
+        mock_etcd.get_vol_byname.return_value = data.volume_qos
+
+        mock_3parclient = self.mock_objects['mock_3parclient']
+        mock_3parclient.copyVolume.return_value = {'taskid': data.TASK_ID}
+        mock_3parclient.getCPG.return_value = {}
+
+
 # Online copy with flash cache - add to vvset fails
 class TestCloneWithFlashCacheAddVVSetFails(CloneVolumeUnitTest):
     def check_response(self, resp):

--- a/test/fake_3par_data.py
+++ b/test/fake_3par_data.py
@@ -76,6 +76,7 @@ volume = {'name': VOLUME_NAME,
           'host': FAKE_DOCKER_HOST,
           'provisioning': THIN,
           'flash_cache': None,
+          'qos_name': None,
           'compression': None,
           'snapshots': []}
 
@@ -149,6 +150,7 @@ volume_compression = {'name': VOLUME_NAME,
                       'compression': 'true',
                       'provisioning': THIN,
                       'flash_cache': None,
+                      'qos_name': None,
                       'snapshots': []}
 
 volume_dedup = {'name': VOLUME_NAME,
@@ -158,6 +160,7 @@ volume_dedup = {'name': VOLUME_NAME,
                 'host': FAKE_DOCKER_HOST,
                 'provisioning': DEDUP,
                 'flash_cache': None,
+                'qos_name': None,
                 'compression': None,
                 'snapshots': []}
 
@@ -168,6 +171,7 @@ volume_qos = {'name': VOLUME_NAME,
               'host': FAKE_DOCKER_HOST,
               'provisioning': THIN,
               'flash_cache': None,
+              'qos_name': "vvk_vvset",
               'compression': None,
               'snapshots': []}
 
@@ -178,6 +182,7 @@ volume_flash_cache = {'name': VOLUME_NAME,
                       'host': FAKE_DOCKER_HOST,
                       'provisioning': THIN,
                       'flash_cache': 'true',
+                      'qos_name': None,
                       'compression': None,
                       'snapshots': []}
 

--- a/test/test_hpe_plugin_v2.py
+++ b/test/test_hpe_plugin_v2.py
@@ -98,6 +98,10 @@ class HpeDockerUnitTestsBase(object):
         test = clonevolume_tester.TestCloneWithFlashCache()
         test.run_test(self)
 
+    def test_clone_with_qos(self):
+        test = clonevolume_tester.TestCloneWithQOS()
+        test.run_test(self)
+
     def test_clone_with_flashcache_add_to_vvset_fails(self):
         test = clonevolume_tester.TestCloneWithFlashCacheAddVVSetFails()
         test.run_test(self)


### PR DESCRIPTION
If source volume is created with qos name, then same qos name should be applied to cloned volume