### PR TITLE
Fixed Issue #121 & #122

### DIFF
--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -873,6 +873,9 @@ class VolumePlugin(object):
 
         qos_filter['enabled'] = qos_detail.get('enabled')
 
+        if qos_detail.get('name'):
+            qos_filter['vvset_name'] = qos_detail.get('name')
+
         if qos_detail.get('bwMaxLimitKB'):
             qos_filter['maxBWS'] = str(qos_detail.get('bwMaxLimitKB')/1024) + " MB/sec"
 
@@ -973,24 +976,24 @@ class VolumePlugin(object):
                     ss_list_to_show.append(snapshot)
                 volume['Status'].update({'Snapshots': ss_list_to_show})
 
-        qos_name = volinfo.get('qos_name')
-        if qos_name is not None:
-            try:
-                qos_detail = self.hpeplugin_driver.get_qos_detail(qos_name)
-                qos_filter = self.get_required_qos_field(qos_detail)
-                volume['Status'].update({'qos_detail': qos_filter})
-            except Exception as ex:
-                msg = (_('unable to get/filter qos from 3par, error is: %s'),
-                       six.text_type(ex))
-                LOG.error(msg)
-                return json.dumps({u"Err": six.text_type(ex)})
+            qos_name = volinfo.get('qos_name')
+            if qos_name is not None:
+                try:
+                    qos_detail = self.hpeplugin_driver.get_qos_detail(qos_name)
+                    qos_filter = self.get_required_qos_field(qos_detail)
+                    volume['Status'].update({'qos_detail': qos_filter})
+                except Exception as ex:
+                    msg = (_('unable to get/filter qos from 3par, error is: %s'),
+                           six.text_type(ex))
+                    LOG.error(msg)
+                    return json.dumps({u"Err": six.text_type(ex)})
 
-        vol_detail = {}
-        vol_detail['size'] = volinfo.get('size')
-        vol_detail['flash_cache'] = volinfo.get('flash_cache')
-        vol_detail['compression'] = volinfo.get('compression')
-        vol_detail['provisioning'] = volinfo.get('provisioning')
-        volume['Status'].update({'volume_detail': vol_detail})
+            vol_detail = {}
+            vol_detail['size'] = volinfo.get('size')
+            vol_detail['flash_cache'] = volinfo.get('flash_cache')
+            vol_detail['compression'] = volinfo.get('compression')
+            vol_detail['provisioning'] = volinfo.get('provisioning')
+            volume['Status'].update({'volume_detail': vol_detail})
 
         response = json.dumps({u"Err": err, u"Volume": volume})
         LOG.debug("Get volume/snapshot: \n%s" % str(response))

--- a/test/getvolume_tester.py
+++ b/test/getvolume_tester.py
@@ -43,11 +43,7 @@ class TestSyncSnapshots(GetSnapshotUnitTest):
         expected = {u'Volume':
                     {u'Devicename': u'', u'Status':
                      {u'Settings': {u'expirationHours': u'10',
-                                    u'retentionHours': u'10'},
-                      u'volume_detail': {u'compression': None,
-                                         u'flash_cache': None,
-                                         u'provisioning': u'thin',
-                                         u'size': 2}},
+                                    u'retentionHours': u'10'}},
                      u'Name': u'volume-d03338a9-9115-48a3-8dfc-'
                               u'35cdfcdc15a7/snapshot-1',
                      u'Mountpoint': u''}, u'Err': u''}
@@ -85,7 +81,8 @@ class TestQosVolume(GetVolumeUnitTest):
                                       u'maxIOPS': u'2000000 IOs/sec',
                                       u'minBWS': u'30 MB/sec',
                                       u'minIOPS': u'10000 IOs/sec',
-                                      u'priority': u'Normal'},
+                                      u'priority': u'Normal',
+                                      u'vvset_name': u'vvk_vvset'},
                       u'volume_detail': {u'compression': None,
                                          u'flash_cache': None,
                                          u'provisioning': u'thin',


### PR DESCRIPTION
Avoid displaying 'volume_details' and 'qos_details' while inspecting snapshot
Display 'vvset_name' also while inspecting qos_volume