### PR TITLE
Mount Conflict Delay to be accepted as parameter in create-volume

### DIFF
--- a/config/setupcfg.py
+++ b/config/setupcfg.py
@@ -44,11 +44,6 @@ host_opts = [
     cfg.BoolOpt('enforce_multipath',
                default=False,
                help='Toggle enforcing of multipath for volume attachments.'),
-    cfg.IntOpt('mount_conflict_delay',
-               default=0,
-               help='Time in seconds to wait for another node to unmount '
-                    'volume before it could be mounted on the current '
-                    'node.'),
 ]
 
 CONF = cfg.CONF

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,11 @@ There are several optional parameters that can be used during volume creation:
 - size -- specifies the desired size in GB of the volume.
 - provisioning -- specifies the type of provisioning to use (thin, full, dedup).
 - flash-cache -- specifies whether flash cache should be used or not (True, False).
-
+- mountConflictDelay -- specifies period in seconds. This parameter is used to wait for a
+mounted volume to gracefully unmount from some node before it can be mounted on the current
+node. If graceful unmount doesn't happen within mountConflictDelay seconds then a forced
+cleanup of VLUN from the backend is performed so that volume can be mounted on the current
+node.
 Note: Setting flash-cache to True does not gurantee flash-cache will be used. The backend system
 must have the appropriate SSD setup configured, too.
 

--- a/hpedockerplugin/etcdutil.py
+++ b/hpedockerplugin/etcdutil.py
@@ -150,6 +150,11 @@ class EtcdUtil(object):
                     return volmember
         return None
 
+    def get_vol_by_id(self, volid):
+        volkey = self.volumeroot + volid
+        result = self.client.read(volkey)
+        return json.loads(result.value)
+
     def get_all_vols(self):
         volumes = self.client.read(self.volumeroot, recursive=True)
         return volumes

--- a/hpedockerplugin/hpe/volume.py
+++ b/hpedockerplugin/hpe/volume.py
@@ -6,12 +6,14 @@ DEFAULT_FLASH_CACHE = None
 DEFAULT_QOS = None
 DEFAULT_MOUNT_VOLUME = "True"
 DEFAULT_COMPRESSION_VAL = None
+DEFAULT_MOUNT_CONFLICT_DELAY = 30
 
 QOS_PRIORITY = {1: 'Low', 2: 'Normal', 3: 'High'}
 
 
 def createvol(name, size=DEFAULT_SIZE, prov=DEFAULT_PROV,
-              flash_cache=None, compression_val=None, qos=None):
+              flash_cache=None, compression_val=None, qos=None,
+              mount_conflict_delay=DEFAULT_MOUNT_CONFLICT_DELAY):
     volume = {}
     volume['id'] = str(uuid.uuid4())
     volume['name'] = volume['id']
@@ -31,5 +33,6 @@ def createvol(name, size=DEFAULT_SIZE, prov=DEFAULT_PROV,
     volume['qos_name'] = qos
     volume['compression'] = compression_val
     volume['snapshots'] = []
+    volume['mount_conflict_delay'] = mount_conflict_delay
 
     return volume

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -161,12 +161,14 @@ class VolumePlugin(object):
         vol_qos = volume.DEFAULT_QOS
         compression_val = volume.DEFAULT_COMPRESSION_VAL
         valid_compression_opts = ['true', 'false']
+        mount_conflict_delay = volume.DEFAULT_MOUNT_CONFLICT_DELAY
 
         # Verify valid Opts arguments.
         valid_volume_create_opts = ['mount-volume', 'compression',
                                     'size', 'provisioning', 'flash-cache',
                                     'cloneOf', 'snapshotOf', 'expirationHours',
-                                    'retentionHours', 'promote', 'qos-name']
+                                    'retentionHours', 'promote', 'qos-name',
+                                    'mountConflictDelay']
 
         if ('Opts' in contents and contents['Opts']):
             for key in contents['Opts']:
@@ -194,6 +196,17 @@ class VolumePlugin(object):
 
             if ('qos-name' in contents['Opts']):
                 vol_qos = str(contents['Opts']['qos-name'])
+
+            if ('mountConflictDelay' in contents['Opts']):
+                mount_conflict_delay_str = str(contents['Opts']
+                                               ['mountConflictDelay'])
+                try:
+                    mount_conflict_delay = int(mount_conflict_delay_str)
+                except ValueError as ex:
+                    return json.dumps({'Err': "Invalid value '%s' specified "
+                                              "for mountConflictDelay. Please"
+                                              "specify an integer value." %
+                                              mount_conflict_delay_str})
 
             # check for valid promoteSnap option and return the result
             if ('promote' in contents['Opts'] and len(contents['Opts']) == 1):
@@ -231,7 +244,8 @@ class VolumePlugin(object):
 
         return self._manager.create_volume(volname, vol_size,
                                            vol_prov, vol_flash,
-                                           compression_val, vol_qos)
+                                           compression_val, vol_qos,
+                                           mount_conflict_delay)
 
     def volumedriver_clone_volume(self, name, opts=None):
         # Repeating the validation here in anticipation that when

--- a/test/createvolume_tester.py
+++ b/test/createvolume_tester.py
@@ -292,6 +292,35 @@ class TestCreateCompressedVolume(CreateVolumeUnitTest):
             {'licenseInfo': {'licenses': [{'name': 'Compression'}]}}
 
 
+class TestCreateCompressedVolumeWithMountConflictDelay(CreateVolumeUnitTest):
+    def get_request_params(self):
+        return {"Name": "test-vol-001",
+                "Opts": {"compression": 'true',
+                         "size": '20',
+                         "provisioning": 'thin',
+                         "mountConflictDelay": '5'}}
+
+    def setup_mock_objects(self):
+        mock_etcd = self.mock_objects['mock_etcd']
+        mock_etcd.get_vol_byname.return_value = None
+
+        mock_3parclient = self.mock_objects['mock_3parclient']
+        mock_3parclient.getWsApiVersion.return_value = \
+            data.wsapi_version_for_compression
+        mock_3parclient.getCPG.return_value = {}
+        mock_3parclient.getStorageSystemInfo.return_value = \
+            {'licenseInfo': {'licenses': [{'name': 'Compression'}]}}
+
+    def check_response(self, resp):
+        self._test_case.assertEqual(resp, {u"Err": ''})
+
+        mock_3parclient = self.mock_objects['mock_3parclient']
+        mock_3parclient.getWsApiVersion.assert_called()
+        mock_3parclient.getCPG.assert_called()
+        mock_3parclient.getStorageSystemInfo.assert_called()
+        mock_3parclient.createVolume.assert_called()
+
+
 class TestCreateCompressedVolumeNegativeSize(CreateVolumeUnitTest):
     def check_response(self, resp):
         expected_msg = 'Invalid input received: To create compression '\

--- a/test/fake_3par_data.py
+++ b/test/fake_3par_data.py
@@ -69,9 +69,14 @@ DEDUP = 'dedup'
 FAKE_ISCSI_PORT = {'portPos': {'node': 8, 'slot': 1, 'cardPort': 1},
                    'protocol': 2,
                    'mode': 2,
-                   'IPAddr': '1.1.1.2',
+                   'IPAddr': '10.50.3.59',
                    'iSCSIName': TARGET_IQN,
                    'linkState': 4}
+
+FAKE_ISCSI_PORTS = [{
+    'IPAddr': '1.1.1.2',
+    'iSCSIName': TARGET_IQN,
+}]
 
 volume = {'name': VOLUME_NAME,
           'id': VOLUME_ID,
@@ -82,7 +87,8 @@ volume = {'name': VOLUME_NAME,
           'flash_cache': None,
           'qos_name': None,
           'compression': None,
-          'snapshots': []}
+          'snapshots': [],
+          'mount_conflict_delay': 3}
 
 json_path_info = \
     '{"connection_info": {"driver_volume_type": "iscsi", ' \
@@ -114,7 +120,8 @@ vol_mounted_on_this_node = {
     'compression': None,
     'snapshots': [],
     'node_mount_info': {THIS_NODE_ID: ['Fake_Mount_id']},
-    'path_info': json_path_info}
+    'path_info': json_path_info,
+    'mount_conflict_delay': 3}
 
 vol_mounted_on_other_node = {
     'name': VOLUME_NAME,
@@ -128,7 +135,8 @@ vol_mounted_on_other_node = {
     'compression': None,
     'snapshots': [],
     'node_mount_info': {OTHER_NODE_ID: ['Fake_Mount_id']},
-    'path_info': path_info}
+    'path_info': path_info,
+    'mount_conflict_delay': 3}
 
 snapshot1 = {'name': SNAPSHOT_NAME1,
              'id': SNAPSHOT_ID1,
@@ -171,7 +179,8 @@ volume_with_snapshots = {
     'provisioning': THIN,
     'flash_cache': None,
     'compression': None,
-    'snapshots': [snapshot1, snapshot2]}
+    'snapshots': [snapshot1, snapshot2],
+    'mount_conflict_delay': 3}
 
 
 volume_with_multilevel_snapshot = {
@@ -183,7 +192,8 @@ volume_with_multilevel_snapshot = {
     'provisioning': THIN,
     'flash_cache': None,
     'compression': None,
-    'snapshots': [snapshot1, snapshot2, snapshot3]}
+    'snapshots': [snapshot1, snapshot2, snapshot3],
+    'mount_conflict_delay': 3}
 
 volume_encrypted = {'name': VOLUME_NAME,
                     'id': VOLUME_ID,
@@ -193,7 +203,8 @@ volume_encrypted = {'name': VOLUME_NAME,
                     'encryption_key_id': 'fake_key',
                     'provisioning': THIN,
                     'flash_cache': None,
-                    'snapshots': []}
+                    'snapshots': [],
+                    'mount_conflict_delay': 3}
 
 volume_dedup_compression = {'name': VOLUME_NAME,
                             'id': VOLUME_ID,
@@ -203,7 +214,8 @@ volume_dedup_compression = {'name': VOLUME_NAME,
                             'compression': None,
                             'flash_cache': None,
                             'provisioning': DEDUP,
-                            'snapshots': []}
+                            'snapshots': [],
+                            'mount_conflict_delay': 3}
 
 volume_compression = {'name': VOLUME_NAME,
                       'id': VOLUME_ID,
@@ -214,7 +226,8 @@ volume_compression = {'name': VOLUME_NAME,
                       'provisioning': THIN,
                       'flash_cache': None,
                       'qos_name': None,
-                      'snapshots': []}
+                      'snapshots': [],
+                      'mount_conflict_delay': 3}
 
 volume_dedup = {'name': VOLUME_NAME,
                 'id': VOLUME_ID,
@@ -225,7 +238,8 @@ volume_dedup = {'name': VOLUME_NAME,
                 'flash_cache': None,
                 'qos_name': None,
                 'compression': None,
-                'snapshots': []}
+                'snapshots': [],
+                'mount_conflict_delay': 3}
 
 volume_qos = {'name': VOLUME_NAME,
               'id': VOLUME_ID,
@@ -236,7 +250,8 @@ volume_qos = {'name': VOLUME_NAME,
               'flash_cache': None,
               'qos_name': "vvk_vvset",
               'compression': None,
-              'snapshots': []}
+              'snapshots': [],
+              'mount_conflict_delay': 3}
 
 volume_flash_cache = {'name': VOLUME_NAME,
                       'id': VOLUME_ID,
@@ -247,7 +262,8 @@ volume_flash_cache = {'name': VOLUME_NAME,
                       'flash_cache': 'true',
                       'qos_name': None,
                       'compression': None,
-                      'snapshots': []}
+                      'snapshots': [],
+                      'mount_conflict_delay': 3}
 
 volume_flash_cache_and_qos = {
     'name': VOLUME_NAME,
@@ -259,7 +275,8 @@ volume_flash_cache_and_qos = {
     'flash_cache': 'true',
     'qos_name': 'vvk_vvset',
     'compression': None,
-    'snapshots': []}
+    'snapshots': [],
+    'mount_conflict_delay': 3}
 
 wwn = ["123456789012345", "123456789054321", "unassigned-wwn1"]
 
@@ -373,62 +390,6 @@ volume_type = {'name': 'gold',
                                'qos:priority': 'low'},
                'deleted_at': None,
                'id': 'gold'}
-
-volume_type_dedup_compression = {'name': 'dedup',
-                                 'deleted': False,
-                                 'updated_at': None,
-                                 'extra_specs': {'cpg': HPE3PAR_CPG2,
-                                                 'provisioning': 'dedup',
-                                                 'compression': 'true'},
-                                 'deleted_at': None,
-                                 'id': VOL_TYPE_ID_DEDUP_COMPRESS}
-
-volume_type_dedup = {'name': 'dedup',
-                     'deleted': False,
-                     'updated_at': None,
-                     'extra_specs': {'cpg': HPE3PAR_CPG2,
-                                     'provisioning': 'dedup'},
-                     'deleted_at': None,
-                     'id': VOLUME_TYPE_ID_DEDUP}
-
-volume_type_flash_cache = {'name': 'flash-cache-on',
-                           'deleted': False,
-                           'updated_at': None,
-                           'extra_specs': {'cpg': HPE3PAR_CPG2,
-                                           'hpe3par:flash_cache': 'true'},
-                           'deleted_at': None,
-                           'id': VOLUME_TYPE_ID_FLASH_CACHE}
-
-flash_cache_3par_keys = {'flash_cache': 'true'}
-
-cpgs = [
-    {'SAGrowth': {'LDLayout': {'diskPatterns': [{'diskType': 2}]},
-                  'incrementMiB': 8192},
-     'SAUsage': {'rawTotalMiB': 24576,
-                 'rawUsedMiB': 768,
-                 'totalMiB': 8192,
-                 'usedMiB': 256},
-     'SDGrowth': {'LDLayout': {'RAIDType': 4,
-                               'diskPatterns': [{'diskType': 2}]},
-                  'incrementMiB': 32768},
-     'SDUsage': {'rawTotalMiB': 49152,
-                 'rawUsedMiB': 1023,
-                 'totalMiB': 36864,
-                 'usedMiB': 1024 * 1},
-     'UsrUsage': {'rawTotalMiB': 57344,
-                  'rawUsedMiB': 43349,
-                  'totalMiB': 43008,
-                  'usedMiB': 1024 * 20},
-     'additionalStates': [],
-     'degradedStates': [],
-     'failedStates': [],
-     'id': 5,
-     'name': HPE3PAR_CPG,
-     'numFPVVs': 2,
-     'numTPVVs': 0,
-     'numTDVVs': 1,
-     'state': 1,
-     'uuid': '29c214aa-62b9-41c8-b198-543f6cf24edf'}]
 
 TASK_ID = '123456789'
 TASK_DONE = 1

--- a/test/mountvolume_tester.py
+++ b/test/mountvolume_tester.py
@@ -753,8 +753,10 @@ class TestVolFencingGracefulUnmount(MountVolumeUnitTest):
 class TestVolFencingForcedUnmount(MountVolumeUnitTest):
     def setup_mock_etcd(self):
         mock_etcd = self.mock_objects['mock_etcd']
-        mock_etcd.get_vol_byname.return_value = copy.deepcopy(
+        vol_mounted_on_other_node = copy.deepcopy(
             data.vol_mounted_on_other_node)
+        mock_etcd.get_vol_byname.return_value = vol_mounted_on_other_node
+        mock_etcd.get_vol_by_id.return_value = vol_mounted_on_other_node
         mock_etcd.get_vol_path_info.return_value = copy.deepcopy(
             data.path_info)
         # Allow child class to make changes
@@ -769,6 +771,9 @@ class TestVolFencingForcedUnmount(MountVolumeUnitTest):
         # mock_client.getVolumeMetaData.return_value = data.volume_metadata
         mock_client.getCPG.return_value = {}
         mock_client.getiSCSIPorts.return_value = [data.FAKE_ISCSI_PORT]
+        mock_client.getVLUN.return_value = {'hostname': 'FakeHostName'}
+        mock_client.getHostVLUNs.return_value = data.iscsi_host_vluns
+        mock_client.getiSCSIPorts.return_value = data.FAKE_ISCSI_PORTS
 
     def setup_mock_fileutil(self):
         mock_fileutil = self.mock_objects['mock_fileutil']


### PR DESCRIPTION
* Removed mount_conflict_delay from configuration file and instead accepting it as a create-volume parameter
* Made changes to the affected unit tests and dependent modules

@hpe-storage , @wdurairaj - Please review the changes