### PR TITLE
Mount/Unmount - Synchronization Issue Fix

### DIFF
--- a/hpedockerplugin/exception.py
+++ b/hpedockerplugin/exception.py
@@ -260,3 +260,7 @@ class HPEDriverAddVvToVvSetFailed(HPEDriverException):
 
 class HPEDriverForceRemoveVLUNFailed(HPEDriverException):
     message = "Forced removal of VLUN failed: %(reason)"
+
+
+class HPEDriverNoVLUNsCreated(HPEDriverException):
+    message = "No new VLUN(s) were created!"

--- a/hpedockerplugin/hpe/hpe_3par_fc.py
+++ b/hpedockerplugin/hpe/hpe_3par_fc.py
@@ -198,7 +198,7 @@ class HPE3PARFCDriver(object):
                     # New vlun creation failed
                     msg = _('No new vlun(s) were created')
                     LOG.error(msg)
-                    raise exception.VolumeDriverException(msg)
+                    raise exception.HPEDriverNoVLUNsCreated()
             else:
                 vlun = existing_vlun
 

--- a/hpedockerplugin/volume_manager.py
+++ b/hpedockerplugin/volume_manager.py
@@ -742,6 +742,7 @@ class VolumeManager(object):
                     LOG.info("Volume not gracefully unmounted by other "
                              "node. Removing VLUNs forcefully from the "
                              "backend...")
+                    LOG.info("%s" % vol)
                     self._force_remove_vlun(vol, is_snap)
                     LOG.info("VLUNs forcefully removed from the backend!")
 
@@ -778,7 +779,7 @@ class VolumeManager(object):
 
         # Call OS Brick to connect volume
         try:
-            device_info = self._connector.\
+            device_info = self._connector. \
                 connect_volume(connection_info['data'])
         except Exception as ex:
             msg = (_('OS Brick connect volume failed, error is: %s'),
@@ -859,41 +860,56 @@ class VolumeManager(object):
         LOG.info('Unmounting volume: %s' % vol)
         if 'node_mount_info' in vol:
             node_mount_info = vol['node_mount_info']
-            if self._node_id in node_mount_info:
-                LOG.info("node_id '%s' present in vol mount info"
-                         % self._node_id)
 
-                mount_id_list = node_mount_info[self._node_id]
+            # Check if this node still owns the volume. If not, then it is
+            # not possible to proceed with cleanup as the volume meta-data
+            # context was modified by other node and it's not relevant for
+            # this node anymore.
+            # TODO: To solve the above issue, when a volume is re-mounted
+            # forcibly on other node, that other node should save the volume
+            # meta-data in a different ETCD root for it to be accessible by
+            # this node. Once this node discovers that the volume is owned
+            # by some other node, it can go to that different ETCD root to
+            # fetch the volume meta-data and do the cleanup.
+            if self._node_id not in node_mount_info:
+                return json.dumps({u"Err": "Volume '%s' is mounted on another"
+                                           " node. Cannot unmount it!" %
+                                           volname})
 
-                LOG.info("Current mount_id_list %s " % mount_id_list)
+            LOG.info("node_id '%s' is present in vol mount info"
+                     % self._node_id)
 
-                try:
-                    mount_id_list.remove(mount_id)
-                except ValueError as ex:
-                    pass
+            mount_id_list = node_mount_info[self._node_id]
 
-                LOG.info("Updating node_mount_info '%s' in etcd..."
-                         % node_mount_info)
-                # Update the mount_id list in etcd
-                self._etcd.update_vol(volid, 'node_mount_info',
-                                      node_mount_info)
+            LOG.info("Current mount_id_list %s " % mount_id_list)
 
-                LOG.info("Updated node_mount_info '%s' in etcd!"
-                         % node_mount_info)
+            try:
+                mount_id_list.remove(mount_id)
+            except ValueError as ex:
+                pass
 
-                if len(mount_id_list) > 0:
-                    # Don't proceed with unmount
-                    LOG.info("Volume still in use by %s containers... "
-                             "no unmounting done!" % len(mount_id_list))
-                    return json.dumps({u"Err": ''})
-                else:
-                    # delete the node_id key from node_mount_info
-                    LOG.info("Removing node_mount_info %s",
-                             node_mount_info)
-                    vol.pop('node_mount_info')
-                    LOG.info("Saving volume to etcd: %s..." % vol)
-                    self._etcd.save_vol(vol)
-                    LOG.info("Volume saved to etcd: %s!" % vol)
+            LOG.info("Updating node_mount_info '%s' in etcd..."
+                     % node_mount_info)
+            # Update the mount_id list in etcd
+            self._etcd.update_vol(volid, 'node_mount_info',
+                                  node_mount_info)
+
+            LOG.info("Updated node_mount_info '%s' in etcd!"
+                     % node_mount_info)
+
+            if len(mount_id_list) > 0:
+                # Don't proceed with unmount
+                LOG.info("Volume still in use by %s containers... "
+                         "no unmounting done!" % len(mount_id_list))
+                return json.dumps({u"Err": ''})
+            else:
+                # delete the node_id key from node_mount_info
+                LOG.info("Removing node_mount_info %s",
+                         node_mount_info)
+                vol.pop('node_mount_info')
+                LOG.info("Saving volume to etcd: %s..." % vol)
+                self._etcd.save_vol(vol)
+                LOG.info("Volume saved to etcd: %s!" % vol)
 
         # TODO: Requirement #5 will bring the flow here but the below flow
         # may result into exception. Need to ensure it doesn't happen
@@ -951,13 +967,8 @@ class VolumeManager(object):
 
         # TODO: Create path_info list as we can mount the volume to multiple
         # hosts at the same time.
-        node_mount_info = {}
-        if 'node_mount_info' in vol:
-            node_mount_info = vol['node_mount_info']
-
         # If this node owns the volume then update path_info
-        if self._node_id in node_mount_info:
-            self._etcd.update_vol(volid, 'path_info', None)
+        self._etcd.update_vol(volid, 'path_info', None)
 
         LOG.info(_LI('path for volume: %(name)s, was successfully removed: '
                      '%(path_name)s'), {'name': volname,

--- a/hpedockerplugin/volume_manager.py
+++ b/hpedockerplugin/volume_manager.py
@@ -779,8 +779,8 @@ class VolumeManager(object):
 
         # Call OS Brick to connect volume
         try:
-            device_info = self._connector. \
-                connect_volume(connection_info['data'])
+            device_info = self._connector.connect_volume(
+                connection_info['data'])
         except Exception as ex:
             msg = (_('OS Brick connect volume failed, error is: %s'),
                    six.text_type(ex))


### PR DESCRIPTION
1. Mounting and Unmounting of the same volume from different nodes simultaneously would corrupt the volume record. Added code to do mounting/umounting in synchronized block.
2. Added code in unmount to not update the path_info only if volume is mounted on local node. If it is mounted on a different node, then path_info is left intact as it has info created by that different node.