### PR TITLE
Fix Bug #134, #135 and #167

### DIFF
--- a/hpedockerplugin/exception.py
+++ b/hpedockerplugin/exception.py
@@ -246,6 +246,10 @@ class HPEDriverCreateVolumeWithQosFailed(HPEDriverException):
     message = ""
 
 
+class HPEDriverGetQosFromVvSetFailed(HPEDriverException):
+    message = ""
+
+
 class HPEDriverSetFlashCacheOnVvsFailed(HPEDriverException):
     message = _("%(reason)s")
 

--- a/hpedockerplugin/hpe/hpe_3par_common.py
+++ b/hpedockerplugin/hpe/hpe_3par_common.py
@@ -333,7 +333,13 @@ class HPE3PARCommon(object):
         return self.client.getPorts()
 
     def get_qos_detail(self, vvset):
-        return self.client.queryQoSRule(vvset)
+        try:
+            return self.client.queryQoSRule(vvset)
+        except Exception as ex:
+            msg = _("Failed to get qos from VV set %s - %s.") %\
+                   (vvset, ex)
+            LOG.error(msg)
+            raise exception.HPEDriverGetQosFromVvSetFailed(ex)
 
     def get_active_target_ports(self):
         ports = self.get_ports()
@@ -787,13 +793,7 @@ class HPE3PARCommon(object):
                     # volume is part of a volume set.
                     vvset_name = self.client.findVolumeSet(volume_name)
                     LOG.debug("Returned vvset_name = %s", vvset_name)
-                    if vvset_name is not None and \
-                       vvset_name.startswith('vvs-'):
-                        # We have a single volume per volume set, so
-                        # remove the volume set.
-                        self.client.deleteVolumeSet(
-                            utils.get_3par_vvs_name(volume['id']))
-                    elif vvset_name is not None:
+                    if vvset_name is not None:
                         # We have a pre-defined volume set just remove the
                         # volume and leave the volume set.
                         self.client.removeVolumeFromVolumeSet(vvset_name,

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -160,22 +160,28 @@ class VolumePlugin(object):
                     return json.dumps({u"Err": six.text_type(msg)})
 
             # Populating the values
-            if ('size' in contents['Opts']):
+            if ('size' in contents['Opts'] and
+                    contents['Opts']['size'] != ""):
                 vol_size = int(contents['Opts']['size'])
 
-            if ('provisioning' in contents['Opts']):
+            if ('provisioning' in contents['Opts'] and
+                    contents['Opts']['provisioning'] != ""):
                 vol_prov = str(contents['Opts']['provisioning'])
 
-            if ('compression' in contents['Opts']):
+            if ('compression' in contents['Opts'] and
+                    contents['Opts']['compression'] != ""):
                 compression_val = str(contents['Opts']['compression'])
 
-            if ('flash-cache' in contents['Opts']):
+            if ('flash-cache' in contents['Opts'] and
+                    contents['Opts']['flash-cache'] != ""):
                 vol_flash = str(contents['Opts']['flash-cache'])
 
-            if ('qos-name' in contents['Opts']):
+            if ('qos-name' in contents['Opts'] and
+                    contents['Opts']['qos-name'] != ""):
                 vol_qos = str(contents['Opts']['qos-name'])
 
-            if ('mountConflictDelay' in contents['Opts']):
+            if ('mountConflictDelay' in contents['Opts'] and
+                    contents['Opts']['mountConflictDelay'] != ""):
                 mount_conflict_delay_str = str(contents['Opts']
                                                ['mountConflictDelay'])
                 try:


### PR DESCRIPTION
#134 :- This fix will not allow user to create a volume when vvset is not associated with QOS
#135 :- Hard-coded prefix 'vvs-' code was removed. now volume will be first removed from the vvset followed by the deletion
#167 :- Now, in case if user gives only flag 'qos-name' and failed to give its value, it will take default one. in case of 'qos-name' it will create volume only and that will NOT be added under any vvset.