### PR TITLE
Removing flash_cache from inspect of snapshot

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -75,7 +75,9 @@ There are couple of optional parameters that can be used during snapshot creatio
 - expirationHours -- specifies the expiration time for snapshot in hours
 - retentionHours  -- specifies the retention time for snapshot in hours
 
-Note: If snapcpg is not configured in hpe.conf then cpg would be used for snapshot
+Note:1. If snapcpg is not configured in hpe.conf then cpg would be used for snapshot.
+     2. expirationHours and retentionHours are valid attributes of a volume but 2.1
+        plugin ignores these parameters and are valid only for snapshots currently.
 
 #### Inspect a snapshot
 

--- a/hpedockerplugin/volume_manager.py
+++ b/hpedockerplugin/volume_manager.py
@@ -450,7 +450,6 @@ class VolumeManager(object):
 
         snap_detail = {}
         snap_detail['size'] = snapinfo.get('size')
-        snap_detail['flash_cache'] = snapinfo.get('flash_cache')
         snap_detail['compression'] = snapinfo.get('compression')
         snap_detail['provisioning'] = snapinfo.get('provisioning')
         snap_detail['is_snap'] = snapinfo.get('is_snap')

--- a/test/getvolume_tester.py
+++ b/test/getvolume_tester.py
@@ -142,7 +142,6 @@ class TestSyncSnapshots(GetSnapshotUnitTest):
     def check_response(self, resp):
         snap_detail = {
             u'compression': None,
-            u'flash_cache': None,
             u'is_snap': True,
             u'parent_id': data.VOLUME_ID,
             u'parent_volume': data.VOLUME_NAME,


### PR DESCRIPTION
Updated a note in usage file regarding usage of retentionHours and expirationHours while creating a volume .
Removed flash_cache field from snap_detail dictionary shown during snapshot inspect to avoid any confusion.