### PR TITLE
Fix for issue #163

### DIFF
--- a/hpedockerplugin/volume_manager.py
+++ b/hpedockerplugin/volume_manager.py
@@ -646,9 +646,16 @@ class VolumeManager(object):
         return self._node_id in node_mount_info
 
     def _update_mount_id_list(self, vol, mount_id):
+        node_mount_info = vol['node_mount_info']
+
+        # Check if mount_id is unique
+        if mount_id in node_mount_info[self._node_id]:
+            LOG.info("Received duplicate mount-id: %s. Ignoring"
+                     % mount_id)
+            return
+
         LOG.info("Adding new mount-id %s to node_mount_info..."
                  % mount_id)
-        node_mount_info = vol['node_mount_info']
         node_mount_info[self._node_id].append(mount_id)
         LOG.info("Updating etcd with modified node_mount_info: %s..."
                  % node_mount_info)


### PR DESCRIPTION
OpenShift: Stale VLUN entries are still present in host and 3par array after deleting ReplicaSets/Deployments.

The logs revealed that plugin receives four mount-volume requests. Expectation is that for each of these requests, there would be a unique mount-id. However, pair of two requests come in with same mount-id. Since plugin doesn't check for the uniqueness of mount-id (as we expected Docker engine would always send a unique value), plugin adds all of them to the mount-id list i.e. four entries in the list.

However, plugin receives only two un-mount requests and this leaves the mount-id-list with two entries. And hence actual un-mounting of the volume doesn't happen which leaves VLUN entries intact both on the host and the array.

Disallow duplicate mount-ids from getting added to mount-id-list.