### PR TITLE
Fix for issue #117: Comment field not visible on 3PAR volume with cloneOf option

### DIFF
--- a/hpedockerplugin/hpe/hpe_3par_common.py
+++ b/hpedockerplugin/hpe/hpe_3par_common.py
@@ -1146,6 +1146,16 @@ class HPE3PARCommon(object):
                     LOG.debug('Copy volume completed: create_cloned_volume: '
                               'id=%s.', dst_volume['id'])
 
+                comments = {'volume_id': dst_volume['id'],
+                            'name': dst_volume['name'],
+                            'type': 'Docker'}
+
+                name = dst_volume.get('display_name', None)
+                if name:
+                    comments['display_name'] = name
+
+                self.client.modifyVolume(dst_3par_vol_name,
+                                         {'comment': json.dumps(comments)})
                 return dst_3par_vol_name
 
         except hpeexceptions.HTTPForbidden:

--- a/test/clonevolume_tester.py
+++ b/test/clonevolume_tester.py
@@ -66,6 +66,7 @@ class TestCloneOfflineCopy(CloneVolumeUnitTest):
         mock_3parclient.createVolume.assert_called()
         mock_3parclient.copyVolume.assert_called()
         mock_3parclient.getTask.assert_called()
+        mock_3parclient.modifyVolume.assert_called()
 
     def get_request_params(self):
         return {"Name": "clone-vol-001",


### PR DESCRIPTION
This fix is applicable to only clone created using offline copy. For online copy, fix is not possible at the moment.

@wdurairaj , @hpe-storage - please review the fix.