### PR TITLE
Fixed sock cleanup issue in legacy plugin

### DIFF
--- a/hpedockerplugin/hpe_plugin_service.py
+++ b/hpedockerplugin/hpe_plugin_service.py
@@ -15,6 +15,8 @@
 """
 Command to start up the Docker plugin.
 """
+import socket
+
 from config.setupcfg import getdefaultconfig, setup_logging
 from hpe_storage_api import VolumePlugin
 
@@ -51,8 +53,24 @@ class HPEDockerPluginService(object):
         self._reactor = reactor
         self._config_file = cfg
 
+        if not self._sock_in_use():
+            self._cleanup()
+
         # Set a cleanup function when reactor stops
         reactor.addSystemEventTrigger("before", "shutdown", self._cleanup)
+
+    @staticmethod
+    def _sock_in_use():
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.connect(PLUGIN_PATH.path)
+        except socket.error:
+            LOG.info("hpe.sock not in use")
+            return False
+        else:
+            LOG.info("hpe.sock in use")
+            sock.close()
+            return True
 
     def _cleanup(self):
         LOG.info(_LI('HPE Docker Volume Plugin Shutdown'))


### PR DESCRIPTION
Check if sock file is not in use in which case it is safe to delete it and the lock file.

@hpe-storage , @wdurairaj  - Please review the fix.