### PR TITLE
volume create help options

### DIFF
--- a/config/create_help.txt
+++ b/config/create_help.txt
@@ -6,7 +6,7 @@ Default Options:
 -o provisioning=x 		x is a provision type of a volume to be created, valid values are thin,dedup,full. Default value is thin.
 
 
-Create Options:
+Create Volume Options:
  -o size=x 			x is a size of a docker volume to be created, deault value of x is 100 (in GiB)
  -o provisioning=x 		x is a provision type of a volume to be created, valid values are thin,dedup,full. Default value is thin.
  -o compression=x 		x is a boolean value, hence x can have true or false. To create a compressed volume, minimum size of a 
@@ -16,11 +16,11 @@ Create Options:
  -o qos-name=x 			x is name of existing VVset on 3PAR on which QoS rules are applied.
  
 
-Clone Options:
+Create Clone Options:
  -o cloneOf=x			x is the name of docker volume (source volume) of which clone to be created.
  -o size=x 			x is the size of cloned volume. x should be greater than or equal to size of a source volume.
  
-Create Snapshot:
+Create Snapshot Options:
  -o virtualCopyOf=x		x is the name of a docker volume for which snapshot/virtual copy is to be created.
  -o retentionHours=x 		x is the number of hours a snapshot will be retained. Snapshot will be retained for x hours from the time of creation.
                                 Snapshot can not be deleted during retention period.

--- a/config/create_help.txt
+++ b/config/create_help.txt
@@ -2,26 +2,28 @@ HPE 3PAR volume plug-in for Docker: Create help
 Create a volume in HPE 3PAR or create a clone of a docker volume or create a snapshot of a docker volume using HPE 3PAR volume plug-in for Docker.
 Default Options:
 -o mountConflictDelay=x 	x is the number of seconds to delay a mount request when there is a conflict(default is 30)
--o size=x 			x is a size of a docker volume to be created, default value is 100GiB
--o provisioning=x 		x is a provision type of a volume that needs to be created, valid values are thin,dedup,full. Default value is thin.
+-o size=x 			x is a size of a docker volume to be created, default value of x is 100 (in GiB)
+-o provisioning=x 		x is a provision type of a volume to be created, valid values are thin,dedup,full. Default value is thin.
 
 
 Create Options:
- -o size=x 			x is a size of a docker volume to be created, deault value is 100GiB
- -o provisioning=x 		x is a provision type of a volume that needs to be created, valid values are thin,dedup,full. Default value is thin.
- -o compression=x 		x is a boolean value, hence x can have true or false. For a compressed volume to be created minimum size of a 
-				volume needs to be 16 GiB, it also requires 3PAR OS version 3.3.1 or more and underlying disks should be SSD.
- -o flash-cache=x 		x specifies whether flash cache should be used or not. Valid vaues are true or false.
- -o qos-name=x 			x is name of existing VVset on 3PAR where QoS rules are applied.
+ -o size=x 			x is a size of a docker volume to be created, deault value of x is 100 (in GiB)
+ -o provisioning=x 		x is a provision type of a volume to be created, valid values are thin,dedup,full. Default value is thin.
+ -o compression=x 		x is a boolean value, hence x can have true or false. To create a compressed volume, minimum size of a 
+				volume should to be 16 GiB. It also requires 3PAR OS version 3.3.1 or more and underlying disks should be SSD.
+ -o flash-cache=x 		x is a boolean value, hence x can have true or false. x specifies whether flash cache should be used or not.
+				Valid vaues are true or false.
+ -o qos-name=x 			x is name of existing VVset on 3PAR on which QoS rules are applied.
  
 
 Clone Options:
- -o cloneOf=x			x is the name of docker volume (source volume) to create a clone of.
- -o size=x 			x is the size of new volume which is getting cloned from a docker volume. x should be greater than size of a source volume.
+ -o cloneOf=x			x is the name of docker volume (source volume) of which clone to be created.
+ -o size=x 			x is the size of cloned volume. x should be greater than or equal to size of a source volume.
  
 Create Snapshot:
- -o virtualCopyOf=x		x is the name of a volume for which snapshot/virtual copy needs to be created.
- -o retentionHours=x 		x is the number of hours a volume needs to be retained. For x hours starting from creation time, volume can not be removed.
- -o expirationHours=x		x is the number of hours after which volume will be removed from 3PAR. If both retentionHours and expirationHours 
-				are used then expirationHours must be greater than retentionHours.
+ -o virtualCopyOf=x		x is the name of a docker volume for which snapshot/virtual copy is to be created.
+ -o retentionHours=x 		x is the number of hours a snapshot will be retained. Snapshot will be retained for x hours from the time of creation.
+                                Snapshot can not be deleted during retention period.
+ -o expirationHours=x		x is the number of hours after which snapshot will be removed from 3PAR. If both retentionHours and expirationHours 
+				are used then expirationHours must be greater than or equal to retentionHours.
 

--- a/config/create_help.txt
+++ b/config/create_help.txt
@@ -1,0 +1,27 @@
+HPE 3PAR volume plug-in for Docker: Create help
+Create a volume in HPE 3PAR or create a clone of a docker volume or create a snapshot of a docker volume using HPE 3PAR volume plug-in for Docker.
+Default Options:
+-o mountConflictDelay=x 	x is the number of seconds to delay a mount request when there is a conflict(default is 30)
+-o size=x 			x is a size of a docker volume to be created, default value is 100GiB
+-o provisioning=x 		x is a provision type of a volume that needs to be created, valid values are thin,dedup,full. Default value is thin.
+
+
+Create Options:
+ -o size=x 			x is a size of a docker volume to be created, deault value is 100GiB
+ -o provisioning=x 		x is a provision type of a volume that needs to be created, valid values are thin,dedup,full. Default value is thin.
+ -o compression=x 		x is a boolean value, hence x can have true or false. For a compressed volume to be created minimum size of a 
+				volume needs to be 16 GiB, it also requires 3PAR OS version 3.3.1 or more and underlying disks should be SSD.
+ -o flash-cache=x 		x specifies whether flash cache should be used or not. Valid vaues are true or false.
+ -o qos-name=x 			x is name of existing VVset on 3PAR where QoS rules are applied.
+ 
+
+Clone Options:
+ -o cloneOf=x			x is the name of docker volume (source volume) to create a clone of.
+ -o size=x 			x is the size of new volume which is getting cloned from a docker volume. x should be greater than size of a source volume.
+ 
+Create Snapshot:
+ -o virtualCopyOf=x		x is the name of a volume for which snapshot/virtual copy needs to be created.
+ -o retentionHours=x 		x is the number of hours a volume needs to be retained. For x hours starting from creation time, volume can not be removed.
+ -o expirationHours=x		x is the number of hours after which volume will be removed from 3PAR. If both retentionHours and expirationHours 
+				are used then expirationHours must be greater than retentionHours.
+

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -146,7 +146,7 @@ class VolumePlugin(object):
                                     'cloneOf', 'virtualCopyOf',
                                     'expirationHours', 'retentionHours',
                                     'qos-name',
-                                    'mountConflictDelay']
+                                    'mountConflictDelay', 'help']
 
         if ('Opts' in contents and contents['Opts']):
             for key in contents['Opts']:
@@ -158,6 +158,14 @@ class VolumePlugin(object):
                             'valid': valid_volume_create_opts, })
                     LOG.error(msg)
                     return json.dumps({u"Err": six.text_type(msg)})
+
+            if ('help' in contents['Opts']):
+                create_help_path = "./config/create_help.txt"
+                create_help_file = open(create_help_path, "r")
+                create_help_content = create_help_file.read()
+                create_help_file.close()
+                LOG.error(create_help_content)
+                return json.dumps({u"Err": create_help_content})
 
             # Populating the values
             if ('size' in contents['Opts'] and


### PR DESCRIPTION
This pull request is to show volume create options using -o help create command.

user has to issue below command to get the supported volume create options.

docker volume create -d <driver_name> -o help