### PR TITLE
Update create_etcd_container.yml

### DIFF
--- a/ansible_3par_docker_plugin/tasks/create_etcd_container.yml
+++ b/ansible_3par_docker_plugin/tasks/create_etcd_container.yml
@@ -4,7 +4,7 @@
 
   - name: run etcd container
     docker_container:
-      name: etcd
+      name: etcd_hpe
       image: "{{ etcd_image }}"
       state: started
       detach: true


### PR DESCRIPTION
change the name of the etcd instance to etcd_hpe in order to prevent conflicts with other built-in etcd deployments (i.e. Rancher deploys etcd containers requiring HPE etcd container to be changed to avoid conflict)