### PR TITLE
Fix for issue 369

### DIFF
--- a/hpedockerplugin/volume_manager.py
+++ b/hpedockerplugin/volume_manager.py
@@ -704,8 +704,8 @@ class VolumeManager(object):
                        'id': snapshot_id,
                        'parent_name': src_vol_name,
                        'parent_id': vol['id'],
-                       'fsMode': vol['fsMode'],
-                       'fsOwner': vol['fsOwner'],
+                       'fsMode': vol.get('fsMode'),
+                       'fsOwner': vol.get('fsOwner'),
                        'expiration_hours': expiration_hrs,
                        'retention_hours': retention_hrs}
         if has_schedule:


### PR DESCRIPTION
This is a fix for issue #369 .
In volume plugin 2.1 support for the fsMode and the fsOwner was not available. While implementing this feature in 3.0  upgrade scenario consideration was missed. Hence while retrieving the volume information from an etcd record, the plugin does not get any information on the fsMode or the fsOwner. When the user tries to create a snapshot now (after upgrade to 3.0) plugin tries to access the value of fsMode from etcd volume information and hence fails with keyError. This change will handle this scenario.

This fix also takes care of #378. When a user creates a snapshot schedule, plugin first creates a schedule on 3PAR and then it takes a snapshot of existing volume. But issue #369 will fail to update the snapshot information. Now with this fix, a schedule can be created without any error.