### PR TITLE
Fix issue 372

### DIFF
--- a/config/create_help.txt
+++ b/config/create_help.txt
@@ -2,6 +2,8 @@ HPE 3PAR volume plug-in for Docker: Create help
 Create a volume in HPE 3PAR or create a clone of a Docker volume or create a snapshot of a Docker volume using HPE 3PAR volume plug-in for Docker.
 Default Options:
 -o mountConflictDelay=x 	x is the number of seconds to delay a mount request when there is a conflict. Default value is 30 seconds.
+                                Note: This flag when passed along with other volume create options like cloneOf, virtualCopyOf, importVol
+                                      it's ignored.
 -o size=x 			x is a size of a Docker volume to be created, default value of x is 100 (in GiB)
 -o provisioning=x 		x is a provision type of a volume to be created, valid values are thin, dedup, full. Default value is thin.
 

--- a/hpedockerplugin/request_validator.py
+++ b/hpedockerplugin/request_validator.py
@@ -102,25 +102,26 @@ def validate_create_volume_opts(contents):
 
 
 def _validate_clone_opts(contents):
-    valid_opts = ['cloneOf', 'size', 'cpg', 'snapcpg']
+    valid_opts = ['cloneOf', 'size', 'cpg', 'snapcpg', 'mountConflictDelay']
     _validate_opts("clone volume", contents, valid_opts)
 
 
 def _validate_snapshot_opts(contents):
-    valid_opts = ['virtualCopyOf', 'retentionHours', 'expirationHours']
+    valid_opts = ['virtualCopyOf', 'retentionHours', 'expirationHours',
+                  'mountConflictDelay']
     _validate_opts("create snapshot", contents, valid_opts)
 
 
 def _validate_snapshot_schedule_opts(contents):
     valid_opts = ['virtualCopyOf', 'scheduleFrequency', 'scheduleName',
-                  'snapshotPrefix', 'expHrs', 'retHrs']
+                  'snapshotPrefix', 'expHrs', 'retHrs', 'mountConflictDelay']
     mandatory_opts = ['scheduleName', 'snapshotPrefix', 'scheduleFrequency']
     _validate_opts("create snapshot schedule", contents,
                    valid_opts, mandatory_opts)
 
 
 def _validate_import_vol_opts(contents):
-    valid_opts = ['importVol', 'backend']
+    valid_opts = ['importVol', 'backend', 'mountConflictDelay']
     _validate_opts("import volume", contents, valid_opts)
 
 

--- a/test/createsnapshot_tester.py
+++ b/test/createsnapshot_tester.py
@@ -302,7 +302,7 @@ class TestCreateSnapshotInvalidOptions(CreateSnapshotUnitTest):
                          "backend": "dummy"}}
 
     def check_response(self, resp):
-        invalid_opts = ['backend', 'mountConflictDelay']
+        invalid_opts = ['backend']
         invalid_opts.sort()
         expected = "Invalid input received: Invalid option(s) " \
                    "%s specified for operation create snapshot. " \


### PR DESCRIPTION
- Allow -o mountConflictDelay with other volume create options like cloneOf, virtualCopyOf, importVol for the flexvolume driver to operate properly.
- Updated help text stating this mountConflictDelay parameter is allowed in cloneOf, virtualCopyOf, importVol, but this will be ignored.