### PR TITLE
Fix Issue #401 - Avoid edge tag on alpine to be compatible on OpenSSL…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.8
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONPATH=${HOME}/python-hpedockerplugin:/root/python-hpedockerplugin


### PR DESCRIPTION
- Using alpine:edge tag for plugin container leads to usage of OpenSSL 1.1.1
- The fix is stay at 3.8 version of alpine tag to be compatible with OpenSSL 1.0.x libraries, since 1.1.1 breaks cryptography / SSL python modules.
