### PR TITLE
Fix missing 'Options' in volume inspect  attribute for clone, import …

### DIFF
--- a/hpedockerplugin/backend_orchestrator.py
+++ b/hpedockerplugin/backend_orchestrator.py
@@ -103,6 +103,11 @@ class Orchestrator(object):
         return current_backend
 
     def __execute_request(self, backend, request, volname, *args, **kwargs):
+        LOG.info('WILLIAM: %s ' % self._manager)
+        LOG.info('WILLIAM backend : %s ' % backend)
+        LOG.info('WILLIAM args %s ' % str(args))
+        LOG.info('WILLIAM kwargs is %s ' % str(kwargs))
+        
         volume_mgr = self._manager.get(backend)
         if volume_mgr:
             # populate the volume backend map for caching
@@ -210,8 +215,13 @@ class Orchestrator(object):
 
     def manage_existing(self, volname, existing_ref, backend, manage_opts):
         return self.__execute_request(backend, 'manage_existing',
+<<<<<<< ed36dcfcfba309dac9e4c7e9176f41e0094d73a6
                                       volname, existing_ref,
                                       backend, manage_opts)
+=======
+                                      volname, existing_ref, backend,
+                                      manage_opts)
+>>>>>>> Rebase with latest code
 
     def volumedriver_list(self):
         # Use the first volume manager list volumes

--- a/hpedockerplugin/backend_orchestrator.py
+++ b/hpedockerplugin/backend_orchestrator.py
@@ -165,13 +165,16 @@ class Orchestrator(object):
 
             return ret_val
 
-    def clone_volume(self, src_vol_name, clone_name, size, cpg, snap_cpg):
+    def clone_volume(self, src_vol_name, clone_name, size, cpg,
+                     snap_cpg, clone_options):
         # Imran: Redundant call to get_volume_backend_details
         # Why is backend being passed to clone_volume when it can be
         # retrieved from src_vol or use DEFAULT if src_vol doesn't have it
         backend = self.get_volume_backend_details(src_vol_name)
+        LOG.info('orchestrator clone_opts : %s' % (clone_options))
         return self._execute_request('clone_volume', src_vol_name, clone_name,
-                                     size, cpg, snap_cpg, backend)
+                                     size, cpg, snap_cpg, backend,
+                                     clone_options)
 
     def create_snapshot(self, src_vol_name, schedName, snapshot_name,
                         snapPrefix, expiration_hrs, exphrs, retention_hrs,
@@ -205,9 +208,10 @@ class Orchestrator(object):
         return self._execute_request('get_volume_snap_details', volname,
                                      snapname, qualified_name)
 
-    def manage_existing(self, volname, existing_ref, backend):
+    def manage_existing(self, volname, existing_ref, backend, manage_opts):
         return self.__execute_request(backend, 'manage_existing',
-                                      volname, existing_ref)
+                                      volname, existing_ref,
+                                      backend, manage_opts)
 
     def volumedriver_list(self):
         # Use the first volume manager list volumes

--- a/hpedockerplugin/backend_orchestrator.py
+++ b/hpedockerplugin/backend_orchestrator.py
@@ -103,11 +103,11 @@ class Orchestrator(object):
         return current_backend
 
     def __execute_request(self, backend, request, volname, *args, **kwargs):
-        LOG.info('WILLIAM: %s ' % self._manager)
-        LOG.info('WILLIAM backend : %s ' % backend)
-        LOG.info('WILLIAM args %s ' % str(args))
-        LOG.info('WILLIAM kwargs is %s ' % str(kwargs))
-        
+        LOG.info(' Operating on backend : %s on volume %s '
+                 % (backend, volname))
+        LOG.info(' Request %s ' % request)
+        LOG.info(' with  args %s ' % str(args))
+        LOG.info(' with  kwargs is %s ' % str(kwargs))
         volume_mgr = self._manager.get(backend)
         if volume_mgr:
             # populate the volume backend map for caching

--- a/hpedockerplugin/backend_orchestrator.py
+++ b/hpedockerplugin/backend_orchestrator.py
@@ -215,13 +215,8 @@ class Orchestrator(object):
 
     def manage_existing(self, volname, existing_ref, backend, manage_opts):
         return self.__execute_request(backend, 'manage_existing',
-<<<<<<< ed36dcfcfba309dac9e4c7e9176f41e0094d73a6
                                       volname, existing_ref,
                                       backend, manage_opts)
-=======
-                                      volname, existing_ref, backend,
-                                      manage_opts)
->>>>>>> Rebase with latest code
 
     def volumedriver_list(self):
         # Use the first volume manager list volumes

--- a/hpedockerplugin/backend_orchestrator.py
+++ b/hpedockerplugin/backend_orchestrator.py
@@ -99,18 +99,13 @@ class Orchestrator(object):
         vol = self.etcd_util.get_vol_byname(volname)
         if vol is not None and 'backend' in vol:
             current_backend = vol['backend']
-            # populate the volume backend map for caching
-            LOG.debug(' Populating cache %s, %s '
-                      % (volname, current_backend))
-            with(self.volume_backend_lock):
-                self.volume_backends_map[volname] = current_backend
 
         return current_backend
 
-    def _execute_request(self, request, volname, *args, **kwargs):
-        backend = self.get_volume_backend_details(volname)
+    def __execute_request(self, backend, request, volname, *args, **kwargs):
         volume_mgr = self._manager.get(backend)
         if volume_mgr:
+            # populate the volume backend map for caching
             return getattr(volume_mgr, request)(volname, *args, **kwargs)
 
         msg = "ERROR: Backend '%s' was NOT initialized successfully." \
@@ -119,14 +114,20 @@ class Orchestrator(object):
         LOG.error(msg)
         return json.dumps({u'Err': msg})
 
+    def _execute_request(self, request, volname, *args, **kwargs):
+        backend = self.get_volume_backend_details(volname)
+        return self.__execute_request(
+            backend, request, volname, *args, **kwargs)
+
     def volumedriver_remove(self, volname):
+        ret_val = self._execute_request('remove_volume', volname)
         with self.volume_backend_lock:
             LOG.debug('Removing entry for volume %s from cache' %
                       volname)
             # This if condition is to make the test code happy
             if volname in self.volume_backends_map:
                 del self.volume_backends_map[volname]
-        return self._execute_request('remove_volume', volname)
+        return ret_val
 
     def volumedriver_unmount(self, volname, vol_mount, mount_id):
         return self._execute_request('unmount_volume',
@@ -140,19 +141,29 @@ class Orchestrator(object):
                             fs_mode, fs_owner,
                             mount_conflict_delay, cpg,
                             snap_cpg, current_backend, rcg_name):
-        return self._manager[current_backend].create_volume(
-            volname,
-            vol_size,
-            vol_prov,
-            vol_flash,
-            compression_val,
-            vol_qos,
-            fs_mode, fs_owner,
-            mount_conflict_delay,
-            cpg,
-            snap_cpg,
-            current_backend,
-            rcg_name)
+        if current_backend in self._manager:
+            ret_val = self.__execute_request(
+                current_backend,
+                'create_volume',
+                volname,
+                vol_size,
+                vol_prov,
+                vol_flash,
+                compression_val,
+                vol_qos,
+                fs_mode, fs_owner,
+                mount_conflict_delay,
+                cpg,
+                snap_cpg,
+                current_backend,
+                rcg_name)
+
+            with self.volume_backend_lock:
+                LOG.debug(' Populating cache %s, %s '
+                          % (volname, current_backend))
+                self.volume_backends_map[volname] = current_backend
+
+            return ret_val
 
     def clone_volume(self, src_vol_name, clone_name, size, cpg, snap_cpg):
         # Imran: Redundant call to get_volume_backend_details
@@ -195,8 +206,8 @@ class Orchestrator(object):
                                      snapname, qualified_name)
 
     def manage_existing(self, volname, existing_ref, backend):
-        return self._execute_request('manage_existing', volname,
-                                     existing_ref, backend)
+        return self.__execute_request(backend, 'manage_existing',
+                                      volname, existing_ref)
 
     def volumedriver_list(self):
         # Use the first volume manager list volumes

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -207,7 +207,8 @@ class VolumePlugin(object):
                 existing_ref = str(contents['Opts']['importVol'])
                 return self.orchestrator.manage_existing(volname,
                                                          existing_ref,
-                                                         current_backend)
+                                                         current_backend,
+                                                         contents['Opts'])
 
             if 'help' in contents['Opts']:
                 return self._process_help(contents['Opts']['help'])
@@ -336,7 +337,10 @@ class VolumePlugin(object):
                                                          mount_conflict_delay,
                                                          opts)
             elif 'cloneOf' in contents['Opts']:
-                return self.volumedriver_clone_volume(name, opts)
+                LOG.info('hpe_storage_api: clone options : %s' %
+                         contents['Opts'])
+                return self.volumedriver_clone_volume(name,
+                                                      contents['Opts'])
             for i in input_list:
                 if i in valid_snap_schedule_opts:
                     if 'virtualCopyOf' not in input_list:
@@ -480,7 +484,7 @@ class VolumePlugin(object):
             LOG.error(msg)
             raise exception.HPEPluginCreateException(reason=msg)
 
-    def volumedriver_clone_volume(self, name, opts=None):
+    def volumedriver_clone_volume(self, name, clone_opts=None):
         # Repeating the validation here in anticipation that when
         # actual REST call for clone is added, this
         # function will have minimal impact
@@ -505,9 +509,11 @@ class VolumePlugin(object):
 
         src_vol_name = str(contents['Opts']['cloneOf'])
         clone_name = contents['Name']
+        LOG.info('hpe_storage_api - volumedriver_clone_volume '
+                 'clone_options 1 : %s ' % clone_opts)
 
         return self.orchestrator.clone_volume(src_vol_name, clone_name, size,
-                                              cpg, snap_cpg)
+                                              cpg, snap_cpg, clone_opts)
 
     def volumedriver_create_snapshot(self, name, mount_conflict_delay,
                                      opts=None):

--- a/test/createsnapshot_tester.py
+++ b/test/createsnapshot_tester.py
@@ -25,6 +25,7 @@ class TestCreateSnapshotDefault(CreateSnapshotUnitTest):
         mock_etcd = self.mock_objects['mock_etcd']
         mock_etcd.get_vol_byname.side_effect = [
             data.volume,
+            data.volume,
             None,
             copy.deepcopy(data.volume),
             None
@@ -50,6 +51,7 @@ class TestCreateSnapshotWithExpiryRetentionTimes(CreateSnapshotUnitTest):
     def setup_mock_objects(self):
         mock_etcd = self.mock_objects['mock_etcd']
         mock_etcd.get_vol_byname.side_effect = [
+            data.volume,
             data.volume,
             None,
             copy.deepcopy(data.volume)
@@ -123,6 +125,7 @@ class TestCreateSnapshotEtcdSaveFails(CreateSnapshotUnitTest):
         mock_etcd = self.mock_objects['mock_etcd']
         mock_etcd.get_vol_byname.side_effect = [
             data.volume,
+            data.volume,
             None,
             copy.deepcopy(data.volume)
         ]
@@ -156,6 +159,7 @@ class TestCreateSnpSchedule(CreateSnapshotUnitTest):
     def setup_mock_objects(self):
         mock_etcd = self.mock_objects['mock_etcd']
         mock_etcd.get_vol_byname.side_effect = [
+            data.volume,
             data.volume,
             None,
             copy.deepcopy(data.volume)


### PR DESCRIPTION
- Fix Issue #394
- Added 'Options' as part of "Status" field in volume inspect to avoid missing that fields when operation is done on node other than one on which the volume was created.