### PR TITLE
Validator change to accept 'size' parameter for snapshot/snapshot schedule options

### DIFF
--- a/config/create_help.txt
+++ b/config/create_help.txt
@@ -69,6 +69,7 @@ Create Snapshot Options:
  -o expirationHours=x		x is the number of hours after which snapshot is removed from 3PAR. If both retentionHours and expirationHours
 				are specified then expirationHours must be greater than or equal to retentionHours.
  -o mountConflictDelay=x 	This option is ignored for this operation. It is present so that it can work with orchestrators like K8S and Openshift.
+ -o size=x                      This option is ignored for this operation. It is present so that it can work with orchestrators like K8S and Openshift.
 
 
 ---------------------------------
@@ -126,6 +127,7 @@ Create Snapshot Schedule:
 -o retHrs=x                     This option is not mandatory. x is an integer which indicates number of hours for which snapshot created via
                                 snapshot schedule will be retained.
 -o mountConflictDelay=x 	This option is ignored for this operation. It is present so that it can work with orchestrators like K8S and Openshift.
+-o size=x                       This option is ignored for this operation. It is present so that it can work with orchestrators like K8S and Openshift.
 
 
 ---------------------------------

--- a/hpedockerplugin/request_validator.py
+++ b/hpedockerplugin/request_validator.py
@@ -100,13 +100,13 @@ class RequestValidator(object):
 
     def _validate_snapshot_opts(self, contents):
         valid_opts = ['virtualCopyOf', 'retentionHours', 'expirationHours',
-                      'mountConflictDelay']
+                      'mountConflictDelay', 'size']
         self._validate_opts("create snapshot", contents, valid_opts)
 
     def _validate_snapshot_schedule_opts(self, contents):
         valid_opts = ['virtualCopyOf', 'scheduleFrequency', 'scheduleName',
                       'snapshotPrefix', 'expHrs', 'retHrs',
-                      'mountConflictDelay']
+                      'mountConflictDelay', 'size']
         mandatory_opts = ['scheduleName', 'snapshotPrefix',
                           'scheduleFrequency']
         self._validate_opts("create snapshot schedule", contents,


### PR DESCRIPTION
This change is done for the docker volume plugin to operate in k8s environments, where the -o virtualCopyOf is used as  parameter in SC (StorageClass)