### PR TITLE
Fix duplicate schedule name when -o scheduleName is passed in SC (issue #390)

### DIFF
--- a/config/create_help.txt
+++ b/config/create_help.txt
@@ -119,6 +119,9 @@ Create Snapshot Schedule:
                                 3. To create snapshot every quarter, specify x as "0 * * 3,6,9,12 *"
                                 4. To create snapshot on Monday, Wednesday and Friday, specify x as "0 * * * 1,3,5"
 -o scheduleName=x               This option is mandatory. x is a string which indicates name for the schedule on 3PAR.
+                                Note: When this parameter is passed with string 'auto' , then the scheduleName is
+                                auto generated with a timestamp. This is to support kubernetes environment where 
+                                this parameter can be used as a storage class option.
 -o snapshotPrefix=x             This option is mandatory. x is prefix string for the scheduled snapshots which will get created on 3PAR.
                                 It is recommended to use 3 letter string. If prefix is abc then name of the snapshot which gets created on the 3PAR
                                 will be in the format abc.@y@@m@@d@@H@@M@@S@

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -608,6 +608,9 @@ class VolumePlugin(object):
                     response = json.dumps({'Err': msg})
                     return response
                 schedName = str(contents['Opts']['scheduleName'])
+                if schedName == "auto":
+                    schedName = self.generate_schedule_with_timestamp()
+
                 snapPrefix = str(contents['Opts']['snapshotPrefix'])
 
                 schedNameLength = len(schedName)
@@ -634,6 +637,14 @@ class VolumePlugin(object):
                                                  mount_conflict_delay,
                                                  has_schedule,
                                                  schedFrequency)
+
+    def generate_schedule_with_timestamp(self):
+        import datetime
+        current_time = datetime.datetime.now()
+        current_time_str = str(current_time)
+        scheduleNameGenerated = current_time_str.replace(' ', '_')
+        LOG.info(' Schedule Name auto generated is %s' % scheduleNameGenerated)
+        return scheduleNameGenerated
 
     @app.route("/VolumeDriver.Mount", methods=["POST"])
     def volumedriver_mount(self, name):

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -642,7 +642,10 @@ class VolumePlugin(object):
         import datetime
         current_time = datetime.datetime.now()
         current_time_str = str(current_time)
-        scheduleNameGenerated = current_time_str.replace(' ', '_')
+        space_replaced = current_time_str.replace(' ', '_')
+        colon_replaced = space_replaced.replace(':', '_')
+        hypen_replaced = colon_replaced.replace('-', '_')
+        scheduleNameGenerated = hypen_replaced
         LOG.info(' Schedule Name auto generated is %s' % scheduleNameGenerated)
         return scheduleNameGenerated
 

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -19,6 +19,7 @@ See https://github.com/docker/docker/tree/master/docs/extend for details.
 """
 import json
 import six
+import datetime
 
 from oslo_log import log as logging
 
@@ -639,7 +640,6 @@ class VolumePlugin(object):
                                                  schedFrequency)
 
     def generate_schedule_with_timestamp(self):
-        import datetime
         current_time = datetime.datetime.now()
         current_time_str = str(current_time)
         space_replaced = current_time_str.replace(' ', '_')


### PR DESCRIPTION
Auto Generate Snapshot Schedule Name if -o scheduleName=auto is passed

After this change, the user of kubernetes will pass this parameter to auto generate the schedule name, and this will avoid duplicate schedule name if multiple PVC's are created out of same SC.

```
parameters:
  scheduleName: "auto"
```