### PR TITLE
Defect fixes and enhancement in the ansible docker volume plugin installer

### DIFF
--- a/ansible_3par_docker_plugin/install_hpe_3par_volume_driver.yml
+++ b/ansible_3par_docker_plugin/install_hpe_3par_volume_driver.yml
@@ -56,30 +56,6 @@
     - name: Create hpe.conf
       include: tasks/create_conf_file.yml
 
-    - name: Populate the etcd cluster IP in hpe.conf
-      ini_file:
-        path: /etc/hpedockerplugin/hpe.conf
-        section: "{{ item }}"
-        option: 'host_etcd_ip_address'
-        value: "{{ (':' + INVENTORY['DEFAULT']['host_etcd_port_number'] | string + ',').join(groups['etcd']) + ':' +  INVENTORY['DEFAULT']['host_etcd_port_number'] | string }}"
-        no_extra_spaces: true
-      with_items:
-        - "{{ INVENTORY.keys()}}"
-      become: yes
-      when: groups['etcd'] | length > 1
-
-    - name: Populate the etcd IP in hpe.conf
-      ini_file:
-        path: /etc/hpedockerplugin/hpe.conf
-        section: "{{ item }}"
-        option: 'host_etcd_ip_address'
-        value: "{{ groups['etcd'][0] }}"
-        no_extra_spaces: true
-      with_items:
-        - "{{ INVENTORY.keys()}}"
-      become: yes
-      when: groups['etcd'] | length == 1
-
     - name: Create 3PAR Docker Volume plugin
       include: tasks/create_3par_docker_volume_plugin.yml
 

--- a/ansible_3par_docker_plugin/properties/etcd_cluster_properties.yml
+++ b/ansible_3par_docker_plugin/properties/etcd_cluster_properties.yml
@@ -29,5 +29,4 @@ etcd_listen_client_url_2: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_port_2
 etcd_initial_advertise_peer_urls: "{{ etcd_url_scheme }}://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ etcd_peer_port }}"
 etcd_listen_peer_urls: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_peer_port }}"
 etcd_initial_cluster_token: etcd-cluster-1
-etcd_initial_cluster: "{{ hostvars[groups['etcd'][0]]['ansible_default_ipv4']['address'] }}={{ etcd_url_scheme }}://{{ hostvars[groups['etcd'][0]]['ansible_default_ipv4']['address'] }}:{{ etcd_peer_port }},{{ hostvars[groups['etcd'][1]]['ansible_default_ipv4']['address'] }}={{ etcd_url_scheme }}://{{ hostvars[groups['etcd'][1]]['ansible_default_ipv4']['address'] }}:{{ etcd_peer_port }},{{ hostvars[groups['etcd'][2]]['ansible_default_ipv4']['address'] }}={{ etcd_url_scheme }}://{{ hostvars[groups['etcd'][2]]['ansible_default_ipv4']['address'] }}:{{ etcd_peer_port }}"
 etcd_initial_cluster_state: "new"

--- a/ansible_3par_docker_plugin/properties/etcd_properties.yml
+++ b/ansible_3par_docker_plugin/properties/etcd_properties.yml
@@ -31,5 +31,4 @@ etcd_listen_client_url_2: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_port_2
 etcd_initial_advertise_peer_urls: "{{ etcd_url_scheme }}://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ etcd_peer_port }}"
 etcd_listen_peer_urls: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_peer_port }}"
 etcd_initial_cluster_token: etcd-cluster-1
-etcd_initial_cluster: "{{ etcd_initial_cluster_name }}={{ etcd_url_scheme }}://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ etcd_peer_port }}"
 etcd_initial_cluster_state: "new"

--- a/ansible_3par_docker_plugin/tasks/create_conf_file.yml
+++ b/ansible_3par_docker_plugin/tasks/create_conf_file.yml
@@ -115,37 +115,12 @@
       path: /etc/hpedockerplugin/hpe.conf
       section: "{{ passwords['results'][item | int]['item'][0] }}"
       option:  "{{ passwords['results'][item | int]['item'][1]['option'] }}"
-      value: "{{ passwords['results'][item | int]['stdout_lines'][0].split('password: ')[1] }} "
+      value: "{{ passwords['results'][item | int]['stdout'].split('password: ')[1] }} "
       no_extra_spaces: true
     with_items:
       - "{{ lookup('sequence','start=0 end='+((INVENTORY.keys() | count)*2 -1) |string,wantlist=True) }}"
     become: yes
-    when:  passwords['results'][item | int]['stdout_lines'] is defined
-    ignore_errors: yes
-
-  - name: Wait 10 seconds
-    wait_for: timeout=10
-
-  - name: Get the encrypted passwords
-    shell: hpe3parencryptor --backend {{ item[0] }} -a {{INVENTORY[item[0]]['encryptor_key']}} "{{ INVENTORY[item[0]][(item[1].value)] }}"
-    ignore_errors: yes
-    register: passwords
-    with_nested:
-      - "{{ INVENTORY.keys()}}"
-      - [{ option: 'hpe3par_password', value: 'hpe3par_password' }, { option: 'san_password', value: 'hpe3par_password' }]
-    when: INVENTORY[item[0]]['encryptor_key'] is defined
-
-  - name: Populate the encrypted passwords in hpe.conf
-    ini_file:
-      path: /etc/hpedockerplugin/hpe.conf
-      section: "{{ passwords['results'][item | int]['item'][0] }}"
-      option:  "{{ passwords['results'][item | int]['item'][1]['option'] }}"
-      value: "{{ passwords['results'][item | int]['stdout_lines'][0].split('password: ')[1] }} "
-      no_extra_spaces: true
-    with_items:
-      - "{{ lookup('sequence','start=0 end='+((INVENTORY.keys() | count)*2 -1) |string,wantlist=True) }}"
-    become: yes
-    when:  passwords['results'][item | int]['stdout_lines'] is defined
+    when:  passwords['results'][item | int]['stdout'] is defined
 
   - name: get the iscsi ports of replication device
     local_action: shell /usr/bin/sshpass -p {{ INVENTORY[item]['replication_device']['hpe3par_password'] }} ssh -oStrictHostKeyChecking=no {{ INVENTORY[item]['replication_device']['hpe3par_username'] }}@{{ INVENTORY[item]['replication_device']['hpe3par_ip'] }} "showport -iscsi" | grep ready | awk '{print $3}'

--- a/ansible_3par_docker_plugin/tasks/create_conf_file.yml
+++ b/ansible_3par_docker_plugin/tasks/create_conf_file.yml
@@ -38,7 +38,13 @@
     local_action: shell /usr/bin/sshpass -p {{ INVENTORY[item]['hpe3par_password'] }} ssh -oStrictHostKeyChecking=no {{ INVENTORY[item]['hpe3par_username'] }}@{{ INVENTORY[item]['hpe3par_ip'] }} "showport -iscsi" | grep ready | awk '{print $3}'
     with_items: "{{ INVENTORY.keys() }}"
     register: primary_iscsi_ports
-    when: INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver'
+    when: INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and not (INVENTORY[item]['vlan_tag'] is defined and INVENTORY[item]['vlan_tag'])
+
+  - name: get the iscsi ports (vlan tagged)
+    local_action: shell /usr/bin/sshpass -p {{ INVENTORY[item]['hpe3par_password'] }} ssh -oStrictHostKeyChecking=no {{ INVENTORY[item]['hpe3par_username'] }}@{{ INVENTORY[item]['hpe3par_ip'] }} "showport -iscsivlans" | awk '{print $3}' | sed -n '1!p'
+    with_items: "{{ INVENTORY.keys() }}"
+    register: primary_iscsi_ports
+    when: INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[item]['vlan_tag'] is defined and INVENTORY[item]['vlan_tag']
 
   - fail:
       msg: "No ISCSI ports found on the primary array"
@@ -126,7 +132,13 @@
     local_action: shell /usr/bin/sshpass -p {{ INVENTORY[item]['replication_device']['hpe3par_password'] }} ssh -oStrictHostKeyChecking=no {{ INVENTORY[item]['replication_device']['hpe3par_username'] }}@{{ INVENTORY[item]['replication_device']['hpe3par_ip'] }} "showport -iscsi" | grep ready | awk '{print $3}'
     with_items: "{{ INVENTORY.keys() }}"
     register: secondary_iscsi_ports
-    when: INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[item]['replication_device'] is defined
+    when: INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[item]['replication_device'] is defined and not (INVENTORY[item]['vlan_tag'] is defined and INVENTORY[item]['vlan_tag'])
+
+  - name: get the iscsi ports of replication device (vlan tagged)
+    local_action: shell /usr/bin/sshpass -p {{ INVENTORY[item]['replication_device']['hpe3par_password'] }} ssh -oStrictHostKeyChecking=no {{ INVENTORY[item]['replication_device']['hpe3par_username'] }}@{{ INVENTORY[item]['replication_device']['hpe3par_ip'] }} "showport -iscsivlans" | awk '{print $3}' | sed -n '1!p'
+    with_items: "{{ INVENTORY.keys() }}"
+    register: secondary_iscsi_ports
+    when: INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[item]['replication_device'] is defined and INVENTORY[item]['vlan_tag'] is defined and INVENTORY[item]['vlan_tag']
 
   - fail:
       msg: "No ISCSI ports found on the secondary array"

--- a/ansible_3par_docker_plugin/tasks/create_conf_file.yml
+++ b/ansible_3par_docker_plugin/tasks/create_conf_file.yml
@@ -43,12 +43,12 @@
   - name: get the iscsi ports (vlan tagged)
     local_action: shell /usr/bin/sshpass -p {{ INVENTORY[item]['hpe3par_password'] }} ssh -oStrictHostKeyChecking=no {{ INVENTORY[item]['hpe3par_username'] }}@{{ INVENTORY[item]['hpe3par_ip'] }} "showport -iscsivlans" | awk '{print $3}' | sed -n '1!p'
     with_items: "{{ INVENTORY.keys() }}"
-    register: primary_iscsi_ports
+    register: primary_iscsi_ports_vlan
     when: INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[item]['vlan_tag'] is defined and INVENTORY[item]['vlan_tag']
 
   - fail:
       msg: "No ISCSI ports found on the primary array"
-    when: primary_iscsi_ports == []
+    when: primary_iscsi_ports == [] and primary_iscsi_ports_vlan == []
 
   - name: Creates HPE Docker plugin directory
     file:
@@ -105,7 +105,19 @@
     with_items:
       - "{{ primary_iscsi_ports.results }}"
     become: yes
-    when: INVENTORY[item['item']]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver'
+    when: INVENTORY[item['item']]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and not (INVENTORY[item['item']]['vlan_tag'] is defined and INVENTORY[item['item']]['vlan_tag'])
+
+  - name: Populate iscsi IPs in hpe.conf (vlan tagged)
+    ini_file:
+      path: /etc/hpedockerplugin/hpe.conf
+      section: "{{ item['item'] }}"
+      option: 'hpe3par_iscsi_ips'
+      value: "{{ ','.join(item['stdout_lines']) }}"
+      no_extra_spaces: true
+    with_items:
+      - "{{ primary_iscsi_ports_vlan.results }}"
+    become: yes
+    when: INVENTORY[item['item']]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[item['item']]['vlan_tag'] is defined and INVENTORY[item['item']]['vlan_tag']
 
   - name: Get the encrypted passwords
     shell: hpe3parencryptor --backend {{ item[0] }} -a {{INVENTORY[item[0]]['encryptor_key']}} "{{ INVENTORY[item[0]][(item[1].value)] }}"
@@ -137,7 +149,7 @@
   - name: get the iscsi ports of replication device (vlan tagged)
     local_action: shell /usr/bin/sshpass -p {{ INVENTORY[item]['replication_device']['hpe3par_password'] }} ssh -oStrictHostKeyChecking=no {{ INVENTORY[item]['replication_device']['hpe3par_username'] }}@{{ INVENTORY[item]['replication_device']['hpe3par_ip'] }} "showport -iscsivlans" | awk '{print $3}' | sed -n '1!p'
     with_items: "{{ INVENTORY.keys() }}"
-    register: secondary_iscsi_ports
+    register: secondary_iscsi_ports_vlan
     when: INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[item]['replication_device'] is defined and INVENTORY[item]['vlan_tag'] is defined and INVENTORY[item]['vlan_tag']
 
   - fail:
@@ -172,7 +184,14 @@
       hpe3par_iscsi_ips: "hpe3par_iscsi_ips: {{ ';'.join(secondary_iscsi_ports['results'][0]['stdout_lines']) }}"
     with_items: "{{ INVENTORY.keys() }}"
     register: secondary_array_iscsi_ips
-    when: INVENTORY[item]['replication_device'] is defined and INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver'
+    when: INVENTORY[item]['replication_device'] is defined and INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and not (INVENTORY[item]['vlan_tag'] is defined and INVENTORY[item]['vlan_tag'])
+
+  - name: Set the secondary array iscsi ip addresses
+    set_fact:
+      hpe3par_iscsi_ips: "hpe3par_iscsi_ips: {{ ';'.join(secondary_iscsi_ports_vlan['results'][0]['stdout_lines']) }}"
+    with_items: "{{ INVENTORY.keys() }}"
+    register: secondary_array_iscsi_ips_vlan
+    when: INVENTORY[item]['replication_device'] is defined and INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[item]['vlan_tag'] is defined and INVENTORY[item]['vlan_tag']
 
   - name: Set the passwords for replication device (non-encrypted passwords)
     set_fact:
@@ -198,7 +217,17 @@
       value: "{{ replication_device['results'][item | int]['ansible_facts']['backend_id'] }},{{ replication_device['results'][item | int]['ansible_facts']['replication_mode'] }},{{ replication_device['results'][item | int]['ansible_facts']['cpg_map'] }},{{ replication_device['results'][item | int]['ansible_facts']['snap_cpg_map'] }},{{ replication_device['results'][item | int]['ansible_facts']['hpe3par_username'] }},{{ replication_device_encrypted_passwords['results'][item | int]['ansible_facts']['hpe3par_password'] }},{{ replication_device['results'][item | int]['ansible_facts']['hpe3par_api_url'] }},{{ replication_device['results'][item | int]['ansible_facts']['san_ip'] }},{{ replication_device['results'][item | int]['ansible_facts']['san_login'] }},{{ replication_device_encrypted_passwords['results'][item | int]['ansible_facts']['san_password'] }}, {{ secondary_array_iscsi_ips['results'][item | int]['ansible_facts']['hpe3par_iscsi_ips'] }}"
       no_extra_spaces: true
     with_items: "{{ lookup('sequence', 'start=0 end='+((replication_device['results'] | length)-1) |string, wantlist=True) }}"
-    when: INVENTORY[replication_device['results'][item | int]['item']]['replication_device'] is defined and INVENTORY[replication_device['results'][item | int]['item']]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[replication_device['results'][item | int]['item']]['encryptor_key'] is defined
+    when: INVENTORY[replication_device['results'][item | int]['item']]['replication_device'] is defined and INVENTORY[replication_device['results'][item | int]['item']]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[replication_device['results'][item | int]['item']]['encryptor_key'] is defined and not (INVENTORY[replication_device['results'][item | int]['item']]['vlan_tag'] is defined and INVENTORY[replication_device['results'][item | int]['item']]['vlan_tag'])
+    
+  - name: Populate the replication device information
+    ini_file:
+      path: /etc/hpedockerplugin/hpe.conf
+      section: "{{ replication_device['results'][item | int]['item'] }}"
+      option: replication_device
+      value: "{{ replication_device['results'][item | int]['ansible_facts']['backend_id'] }},{{ replication_device['results'][item | int]['ansible_facts']['replication_mode'] }},{{ replication_device['results'][item | int]['ansible_facts']['cpg_map'] }},{{ replication_device['results'][item | int]['ansible_facts']['snap_cpg_map'] }},{{ replication_device['results'][item | int]['ansible_facts']['hpe3par_username'] }},{{ replication_device_encrypted_passwords['results'][item | int]['ansible_facts']['hpe3par_password'] }},{{ replication_device['results'][item | int]['ansible_facts']['hpe3par_api_url'] }},{{ replication_device['results'][item | int]['ansible_facts']['san_ip'] }},{{ replication_device['results'][item | int]['ansible_facts']['san_login'] }},{{ replication_device_encrypted_passwords['results'][item | int]['ansible_facts']['san_password'] }}, {{ secondary_array_iscsi_ips_vlan['results'][item | int]['ansible_facts']['hpe3par_iscsi_ips'] }}"
+      no_extra_spaces: true
+    with_items: "{{ lookup('sequence', 'start=0 end='+((replication_device['results'] | length)-1) |string, wantlist=True) }}"
+    when: INVENTORY[replication_device['results'][item | int]['item']]['replication_device'] is defined and INVENTORY[replication_device['results'][item | int]['item']]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[replication_device['results'][item | int]['item']]['encryptor_key'] is defined and INVENTORY[replication_device['results'][item | int]['item']]['vlan_tag'] is defined and INVENTORY[replication_device['results'][item | int]['item']]['vlan_tag']
 
   - name: Populate the replication device information
     ini_file:
@@ -218,7 +247,17 @@
       value: "{{ replication_device['results'][item | int]['ansible_facts']['backend_id'] }},{{ replication_device['results'][item | int]['ansible_facts']['replication_mode'] }},{{ replication_device['results'][item | int]['ansible_facts']['cpg_map'] }},{{ replication_device['results'][item | int]['ansible_facts']['snap_cpg_map'] }},{{ replication_device['results'][item | int]['ansible_facts']['hpe3par_username'] }},{{ replication_device_unencrypted_passwords['results'][item | int]['ansible_facts']['hpe3par_password'] }},{{ replication_device['results'][item | int]['ansible_facts']['hpe3par_api_url'] }},{{ replication_device['results'][item | int]['ansible_facts']['san_ip'] }},{{ replication_device['results'][item | int]['ansible_facts']['san_login'] }},{{ replication_device_unencrypted_passwords['results'][item | int]['ansible_facts']['san_password'] }}, {{ secondary_array_iscsi_ips['results'][item | int]['ansible_facts']['hpe3par_iscsi_ips'] }}"
       no_extra_spaces: true
     with_items: "{{ lookup('sequence', 'start=0 end='+((replication_device['results'] | length)-1) |string, wantlist=True) }}"
-    when: INVENTORY[replication_device['results'][item | int]['item']]['replication_device'] is defined and INVENTORY[replication_device['results'][item | int]['item']]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[replication_device['results'][item | int]['item']]['encryptor_key'] is not defined
+    when: INVENTORY[replication_device['results'][item | int]['item']]['replication_device'] is defined and INVENTORY[replication_device['results'][item | int]['item']]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[replication_device['results'][item | int]['item']]['encryptor_key'] is not defined and not (INVENTORY[replication_device['results'][item | int]['item']]['vlan_tag'] is defined and INVENTORY[replication_device['results'][item | int]['item']]['vlan_tag'])
+    
+  - name: Populate the replication device information
+    ini_file:
+      path: /etc/hpedockerplugin/hpe.conf
+      section: "{{ replication_device['results'][item | int]['item'] }}"
+      option: replication_device
+      value: "{{ replication_device['results'][item | int]['ansible_facts']['backend_id'] }},{{ replication_device['results'][item | int]['ansible_facts']['replication_mode'] }},{{ replication_device['results'][item | int]['ansible_facts']['cpg_map'] }},{{ replication_device['results'][item | int]['ansible_facts']['snap_cpg_map'] }},{{ replication_device['results'][item | int]['ansible_facts']['hpe3par_username'] }},{{ replication_device_unencrypted_passwords['results'][item | int]['ansible_facts']['hpe3par_password'] }},{{ replication_device['results'][item | int]['ansible_facts']['hpe3par_api_url'] }},{{ replication_device['results'][item | int]['ansible_facts']['san_ip'] }},{{ replication_device['results'][item | int]['ansible_facts']['san_login'] }},{{ replication_device_unencrypted_passwords['results'][item | int]['ansible_facts']['san_password'] }}, {{ secondary_array_iscsi_ips_vlan['results'][item | int]['ansible_facts']['hpe3par_iscsi_ips'] }}"
+      no_extra_spaces: true
+    with_items: "{{ lookup('sequence', 'start=0 end='+((replication_device['results'] | length)-1) |string, wantlist=True) }}"
+    when: INVENTORY[replication_device['results'][item | int]['item']]['replication_device'] is defined and INVENTORY[replication_device['results'][item | int]['item']]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[replication_device['results'][item | int]['item']]['encryptor_key'] is not defined and INVENTORY[replication_device['results'][item | int]['item']]['vlan_tag'] is defined and INVENTORY[replication_device['results'][item | int]['item']]['vlan_tag']
 
   - name: Populate the replication device information
     ini_file:

--- a/ansible_3par_docker_plugin/tasks/create_conf_file.yml
+++ b/ansible_3par_docker_plugin/tasks/create_conf_file.yml
@@ -1,4 +1,15 @@
 ---
+  - name: Stop docker container
+    docker_container:
+      name: plugin_container
+      image: "{{ INVENTORY['DEFAULT']['volume_plugin'] }}"
+      state: stopped
+
+  - name: remove the existing configuration file
+    file:
+      path: /etc/hpedockerplugin/hpe.conf
+      state: absent
+
   - name: Populate the etcd cluster IP in hpe.conf
     ini_file:
       path: /etc/hpedockerplugin/hpe.conf
@@ -22,17 +33,6 @@
       - "{{ INVENTORY.keys()}}"
     become: yes
     when: groups['etcd'] is not defined or (groups['etcd'] is defined and groups['etcd'] | length == 1)
-
-  - name: Stop docker container
-    docker_container:
-      name: plugin_container
-      image: "{{ INVENTORY['DEFAULT']['volume_plugin'] }}"
-      state: stopped
-
-  - name: remove the existing configuration file
-    file:
-      path: /etc/hpedockerplugin/hpe.conf
-      state: absent
 
   - name: get the iscsi ports
     local_action: shell /usr/bin/sshpass -p {{ INVENTORY[item]['hpe3par_password'] }} ssh -oStrictHostKeyChecking=no {{ INVENTORY[item]['hpe3par_username'] }}@{{ INVENTORY[item]['hpe3par_ip'] }} "showport -iscsi" | grep ready | awk '{print $3}'

--- a/ansible_3par_docker_plugin/tasks/create_conf_file.yml
+++ b/ansible_3par_docker_plugin/tasks/create_conf_file.yml
@@ -32,19 +32,33 @@
     with_items:
       - "{{ INVENTORY.keys()}}"
     become: yes
-    when: groups['etcd'] is not defined or (groups['etcd'] is defined and groups['etcd'] | length == 1)
+    when: groups['etcd'] is defined and groups['etcd'] | length == 1
+
+  - name: Populate the etcd IP in hpe.conf
+    ini_file:
+      path: /etc/hpedockerplugin/hpe.conf
+      section: "{{ item }}"
+      option: 'host_etcd_ip_address'
+      value: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+      no_extra_spaces: true
+    with_items:
+      - "{{ INVENTORY.keys()}}"
+    become: yes
+    when: groups['etcd'] is not defined
 
   - name: get the iscsi ports
     local_action: shell /usr/bin/sshpass -p {{ INVENTORY[item]['hpe3par_password'] }} ssh -oStrictHostKeyChecking=no {{ INVENTORY[item]['hpe3par_username'] }}@{{ INVENTORY[item]['hpe3par_ip'] }} "showport -iscsi" | grep ready | awk '{print $3}'
     with_items: "{{ INVENTORY.keys() }}"
     register: primary_iscsi_ports
     when: INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and not (INVENTORY[item]['vlan_tag'] is defined and INVENTORY[item]['vlan_tag'])
+    no_log: True
 
   - name: get the iscsi ports (vlan tagged)
     local_action: shell /usr/bin/sshpass -p {{ INVENTORY[item]['hpe3par_password'] }} ssh -oStrictHostKeyChecking=no {{ INVENTORY[item]['hpe3par_username'] }}@{{ INVENTORY[item]['hpe3par_ip'] }} "showport -iscsivlans" | awk '{print $3}' | sed -n '1!p'
     with_items: "{{ INVENTORY.keys() }}"
     register: primary_iscsi_ports_vlan
     when: INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[item]['vlan_tag'] is defined and INVENTORY[item]['vlan_tag']
+    no_log: True
 
   - fail:
       msg: "No ISCSI ports found on the primary array"
@@ -106,6 +120,7 @@
       - "{{ primary_iscsi_ports.results }}"
     become: yes
     when: INVENTORY[item['item']]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and not (INVENTORY[item['item']]['vlan_tag'] is defined and INVENTORY[item['item']]['vlan_tag'])
+    no_log: True
 
   - name: Populate iscsi IPs in hpe.conf (vlan tagged)
     ini_file:
@@ -118,6 +133,7 @@
       - "{{ primary_iscsi_ports_vlan.results }}"
     become: yes
     when: INVENTORY[item['item']]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[item['item']]['vlan_tag'] is defined and INVENTORY[item['item']]['vlan_tag']
+    no_log: True
 
   - name: Get the encrypted passwords
     shell: hpe3parencryptor --backend {{ item[0] }} -a {{INVENTORY[item[0]]['encryptor_key']}} "{{ INVENTORY[item[0]][(item[1].value)] }}"
@@ -145,12 +161,14 @@
     with_items: "{{ INVENTORY.keys() }}"
     register: secondary_iscsi_ports
     when: INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[item]['replication_device'] is defined and not (INVENTORY[item]['vlan_tag'] is defined and INVENTORY[item]['vlan_tag'])
+    no_log: True
 
   - name: get the iscsi ports of replication device (vlan tagged)
     local_action: shell /usr/bin/sshpass -p {{ INVENTORY[item]['replication_device']['hpe3par_password'] }} ssh -oStrictHostKeyChecking=no {{ INVENTORY[item]['replication_device']['hpe3par_username'] }}@{{ INVENTORY[item]['replication_device']['hpe3par_ip'] }} "showport -iscsivlans" | awk '{print $3}' | sed -n '1!p'
     with_items: "{{ INVENTORY.keys() }}"
     register: secondary_iscsi_ports_vlan
     when: INVENTORY[item]['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' and INVENTORY[item]['replication_device'] is defined and INVENTORY[item]['vlan_tag'] is defined and INVENTORY[item]['vlan_tag']
+    no_log: True
 
   - fail:
       msg: "No ISCSI ports found on the secondary array"
@@ -200,6 +218,7 @@
     with_items: "{{ INVENTORY.keys() }}"
     register: replication_device_unencrypted_passwords
     when: INVENTORY[item]['replication_device'] is defined and INVENTORY[item]['encryptor_key'] is not defined
+    no_log: True
 
   - name: Set the passwords for replication device (encrypted passwords)
     set_fact:
@@ -208,6 +227,7 @@
     with_items: "{{ replication_device_passwords.results }}"
     register: replication_device_encrypted_passwords
     when: INVENTORY[item['item'][0]]['replication_device'] is defined and INVENTORY[item['item'][0]]['encryptor_key'] is defined
+    no_log: True
 
   - name: Populate the replication device information
     ini_file:

--- a/ansible_3par_docker_plugin/tasks/create_conf_file.yml
+++ b/ansible_3par_docker_plugin/tasks/create_conf_file.yml
@@ -1,4 +1,29 @@
 ---
+
+  - name: Populate the etcd cluster IP in hpe.conf
+    ini_file:
+      path: /etc/hpedockerplugin/hpe.conf
+      section: "{{ item }}"
+      option: 'host_etcd_ip_address'
+      value: "{{ (':' + INVENTORY['DEFAULT']['host_etcd_port_number'] | string + ',').join(groups['etcd']) + ':' +  INVENTORY['DEFAULT']['host_etcd_port_number'] | string }}"
+      no_extra_spaces: true
+    with_items:
+      - "{{ INVENTORY.keys()}}"
+    become: yes
+    when: groups['etcd'] is defined and groups['etcd'] | length > 1
+
+  - name: Populate the etcd IP in hpe.conf
+    ini_file:
+      path: /etc/hpedockerplugin/hpe.conf
+      section: "{{ item }}"
+      option: 'host_etcd_ip_address'
+      value: "{{ groups['etcd'][0] }}"
+      no_extra_spaces: true
+    with_items:
+      - "{{ INVENTORY.keys()}}"
+    become: yes
+    when: groups['etcd'] is not defined or (groups['etcd'] is defined and groups['etcd'] | length == 1)
+
   - name: get the iscsi ports
     local_action: shell /usr/bin/sshpass -p {{ INVENTORY[item]['hpe3par_password'] }} ssh -oStrictHostKeyChecking=no {{ INVENTORY[item]['hpe3par_username'] }}@{{ INVENTORY[item]['hpe3par_ip'] }} "showport -iscsi" | grep ready | awk '{print $3}'
     with_items: "{{ INVENTORY.keys() }}"
@@ -41,18 +66,6 @@
       - [{ option: 'ssh_hosts_key_file', value: 'ssh_hosts_key_file' }, { option: 'logging', value: 'logging' }, { option: 'hpe3par_debug', value: 'hpe3par_debug' }, { option: 'suppress_requests_ssl_warning', value: 'suppress_requests_ssl_warning' }, { option: 'hpe3par_snapcpg', value: 'hpe3par_snapcpg' }, { option: 'hpe3par_iscsi_chap_enabled', value: 'hpe3par_iscsi_chap_enabled' }, { option: 'use_multipath', value: 'use_multipath' }, { option: 'enforce_multipath', value: 'enforce_multipath' }, { option: 'san_ip', value: 'hpe3par_ip' }, { option: 'san_login', value: 'hpe3par_username' }, { option: 'san_password', value: 'hpe3par_password' }, { option: 'backend_id', value: 'backend_id' }]
     become: yes
     when:  item.1.value in INVENTORY[item.0].keys()
-
-  - name: Populate etcd IP in hpe.conf
-    ini_file:
-      path: /etc/hpedockerplugin/hpe.conf
-      section: "{{ item[0] }}"
-      option: "{{ item[1]['option'] }}"
-      value: "{{ item[1]['value'] }}"
-      no_extra_spaces: true
-    with_nested:
-      - "{{ INVENTORY.keys()}}"
-      - [{ option: 'host_etcd_ip_address', value: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}" }]
-    become: yes
 
   - name: Populate WSAPI URL in hpe.conf
     ini_file:

--- a/ansible_3par_docker_plugin/tasks/create_etcd_container.yml
+++ b/ansible_3par_docker_plugin/tasks/create_etcd_container.yml
@@ -2,6 +2,15 @@
   - name: load etcd settings
     include_vars: '../properties/etcd_cluster_properties.yml'
 
+  - name: Initialize the etcd cluster var
+    set_fact:
+      etcd_initial_cluster: ''
+
+  - name: Create the etcd cluster var
+    set_fact:
+      etcd_initial_cluster: "{{ etcd_initial_cluster }},{{ hostvars[groups['etcd'][item | int]]['ansible_default_ipv4']['address'] }}={{ etcd_url_scheme }}://{{ hostvars[groups['etcd'][item | int]]['ansible_default_ipv4']['address'] }}:{{ etcd_peer_port }}"
+    with_items: "{{ lookup('sequence','start=0 end='+((groups['etcd'] | count) -1) |string,wantlist=True) }}"
+
   - name: run etcd container
     docker_container:
       name: etcd_hpe
@@ -18,7 +27,7 @@
         ETCD_LISTEN_CLIENT_URLS: "{{ etcd_listen_client_url_1 }},{{ etcd_listen_client_url_2 }}"
         ETCD_INITIAL_ADVERTISE_PEER_URLS: "{{ etcd_initial_advertise_peer_urls }}"
         ETCD_LISTEN_PEER_URLS: "{{ etcd_listen_peer_urls }}"
-        ETCD_INITIAL_CLUSTER: "{{ etcd_initial_cluster }}"
+        ETCD_INITIAL_CLUSTER: "{{ etcd_initial_cluster[1:] }}" 
         ETCD_INITIAL_CLUSTER_TOKEN: "{{ etcd_initial_cluster_token }}"
         ETCD_INITIAL_CLUSTER_STATE: "{{ etcd_initial_cluster_state }}"
       restart_policy: always

--- a/ansible_3par_docker_plugin/uninstall/remove_doryd_service.yml
+++ b/ansible_3par_docker_plugin/uninstall/remove_doryd_service.yml
@@ -1,9 +1,15 @@
 ---
+  - name: Check that the doryd.service file exists
+    stat:
+      path: /etc/systemd/system/doryd.service
+    register: stat_result
+
   - name: stop doryd service, also issue daemon-reload to pick up config changes
     service:
       state: stopped
       enabled: no
       name: doryd.service
+    when: stat_result.stat.exists
 
   - pause:
       seconds: 5


### PR DESCRIPTION
- Fix for issue where hpe3parencyrptor failed to encrypt password when etcd container is not installed on a worker node
- Fixed an issue where the encrypted password is not properly populated
- Fix for the issue where different 3PAR commands are placed depending on the value to vlun tagging in the plugin configuration properties file
- Fixed an issue where the number of etcds were fixed(hardcoded) to 3
- Hide the ssh commands which contains the array passwords
- Fixed an issue during uninstall of docker volume plugin