### PR TITLE
Ability to create a regular volume from a replicated backend

### DIFF
--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -423,9 +423,9 @@ class VolumePlugin(object):
 
         if replication_device and not rcg_name:
             LOG.info("'%s' is a replication enabled backend. "
-                  "'replicationGroup' is not specified in the create volume "
-                  "command. Proceeding to create a regular volume without "
-                  "remote copy capabilities." % (backend_name))
+                     "'replicationGroup' is not specified in the create volume "
+                     "command. Proceeding to create a regular volume without "
+                     "remote copy capabilities." % (backend_name))
 
         if rcg_name and replication_device:
 

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -424,7 +424,7 @@ class VolumePlugin(object):
         if replication_device and not rcg_name:
             LOG.info("'%s' is a replication enabled backend. " \
                   "'replicationGroup' is not specified in the create volume " \
-                  "command. Proceeding to create a regular volume without" \
+                  "command. Proceeding to create a regular volume without " \
                   "remote copy capabilities." % (backend_name))
 
         if rcg_name and replication_device:

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -423,9 +423,10 @@ class VolumePlugin(object):
 
         if replication_device and not rcg_name:
             LOG.info("'%s' is a replication enabled backend. "
-                     "'replicationGroup' is not specified in the create volume "
-                     "command. Proceeding to create a regular volume without "
-                     "remote copy capabilities." % (backend_name))
+                     "'replicationGroup' is not specified in the create "
+                     "volume command. Proceeding to create a regular "
+                     "volume without remote copy "
+                     "capabilities." % (backend_name))
 
         if rcg_name and replication_device:
 

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -422,9 +422,9 @@ class VolumePlugin(object):
             raise exception.InvalidInput(reason=msg)
 
         if replication_device and not rcg_name:
-            LOG.info("'%s' is a replication enabled backend. " \
-                  "'replicationGroup' is not specified in the create volume " \
-                  "command. Proceeding to create a regular volume without " \
+            LOG.info("'%s' is a replication enabled backend. "
+                  "'replicationGroup' is not specified in the create volume "
+                  "command. Proceeding to create a regular volume without "
                   "remote copy capabilities." % (backend_name))
 
         if rcg_name and replication_device:

--- a/hpedockerplugin/hpe_storage_api.py
+++ b/hpedockerplugin/hpe_storage_api.py
@@ -422,17 +422,10 @@ class VolumePlugin(object):
             raise exception.InvalidInput(reason=msg)
 
         if replication_device and not rcg_name:
-            backend_names = list(self._backend_configs.keys())
-            backend_names.sort()
-
-            msg = "'%s' is a replication enabled backend. " \
-                  "Request to create replicated volume cannot be fulfilled " \
-                  "without specifying 'replicationGroup' option in the " \
-                  "request. Please either specify 'replicationGroup' or use " \
-                  "a normal backend and execute the request again. List of " \
-                  "backends defined in hpe.conf: %s" % (backend_name,
-                                                        backend_names)
-            raise exception.InvalidInput(reason=msg)
+            LOG.info("'%s' is a replication enabled backend. " \
+                  "'replicationGroup' is not specified in the create volume " \
+                  "command. Proceeding to create a regular volume without" \
+                  "remote copy capabilities." % (backend_name))
 
         if rcg_name and replication_device:
 

--- a/hpedockerplugin/request_validator.py
+++ b/hpedockerplugin/request_validator.py
@@ -27,7 +27,7 @@ class RequestValidator(object):
             self._validate_snapshot_opts
         operations_map['cloneOf'] = \
             self._validate_clone_opts
-        operations_map['importVol'] = \	
+        operations_map['importVol'] = \
             self._validate_import_vol_opts
         operations_map['replicationGroup'] = \
             self._validate_rcg_opts

--- a/hpedockerplugin/request_validator.py
+++ b/hpedockerplugin/request_validator.py
@@ -27,8 +27,6 @@ class RequestValidator(object):
             self._validate_snapshot_opts
         operations_map['cloneOf'] = \
             self._validate_clone_opts
-        operations_map['importVol'] = \
-            self._validate_import_vol_opts
         operations_map['replicationGroup'] = \
             self._validate_rcg_opts
         operations_map['help'] = self._validate_help_opt
@@ -111,31 +109,6 @@ class RequestValidator(object):
                           'scheduleFrequency']
         self._validate_opts("create snapshot schedule", contents,
                             valid_opts, mandatory_opts)
-
-    def _validate_import_vol_opts(self, contents):
-        valid_opts = ['importVol', 'backend', 'mountConflictDelay']
-        self._validate_opts("import volume", contents, valid_opts)
-
-        # Replication enabled backend cannot be used for volume import
-        if 'Opts' in contents and contents['Opts']:
-            backend_name = contents['Opts'].get('backend', None)
-            if not backend_name:
-                backend_name = 'DEFAULT'
-            try:
-                config = self._backend_configs[backend_name]
-            except KeyError:
-                backend_names = list(self._backend_configs.keys())
-                backend_names.sort()
-                msg = "ERROR: Backend '%s' doesn't exist. Available " \
-                      "backends are %s. Please use " \
-                      "a valid backend name and retry." % \
-                      (backend_name, backend_names)
-                raise exception.InvalidInput(reason=msg)
-
-            if config.replication_device:
-                msg = "ERROR: Import volume not allowed with replication " \
-                      "enabled backend '%s'" % backend_name
-                raise exception.InvalidInput(reason=msg)
 
     def _validate_rcg_opts(self, contents):
         valid_opts = ['replicationGroup', 'size', 'provisioning',

--- a/hpedockerplugin/volume_manager.py
+++ b/hpedockerplugin/volume_manager.py
@@ -1397,8 +1397,10 @@ class VolumeManager(object):
 
         pri_connection_info = None
         sec_connection_info = None
-        # Check if replication is configured and volume is populated by with the RCG
-        if self.tgt_bkend_config and 'rcg_info' in vol and vol['rcg_info'] is not None:
+        # Check if replication is configured and volume is
+        # populated with the RCG
+        if (self.tgt_bkend_config and 'rcg_info' in vol and
+                vol['rcg_info'] is not None):
             LOG.info("This is a replication setup")
             # Check if this is Active/Passive based replication
             if self.tgt_bkend_config.quorum_witness_ip:

--- a/hpedockerplugin/volume_manager.py
+++ b/hpedockerplugin/volume_manager.py
@@ -1397,19 +1397,9 @@ class VolumeManager(object):
 
         pri_connection_info = None
         sec_connection_info = None
-        # Check if replication is configured
-        if self.tgt_bkend_config:
+        # Check if replication is configured and volume is populated by with the RCG
+        if self.tgt_bkend_config and 'rcg_info' in vol and vol['rcg_info'] is not None:
             LOG.info("This is a replication setup")
-            # TODO: This is where existing volume can be added to RCG
-            # after enabling replication configuration in hpe.conf
-            if 'rcg_info' not in vol or not vol['rcg_info']:
-                msg = "Volume %s is not a replicated volume. It seems" \
-                      "the backend configuration was modified to be a" \
-                      "replication configuration after volume creation."\
-                      % volname
-                LOG.error(msg)
-                raise exception.HPEPluginMountException(reason=msg)
-
             # Check if this is Active/Passive based replication
             if self.tgt_bkend_config.quorum_witness_ip:
                 LOG.info("Peer Persistence has been configured")

--- a/hpedockerplugin/volume_manager.py
+++ b/hpedockerplugin/volume_manager.py
@@ -372,6 +372,12 @@ class VolumeManager(object):
             LOG.exception(msg)
             return json.dumps({u"Err": six.text_type(msg)})
 
+        if ('rcopyStatus' in existing_ref_details and
+                existing_ref_details['rcopyStatus'] != 1):
+            msg = 'ERROR: Volume associated with a replication group '\
+                  'cannot be imported'
+            raise exception.InvalidInput(reason=msg)
+
         vvset_detail = self._hpeplugin_driver.get_vvset_from_volume(
             existing_ref_details['name'])
         if vvset_detail is not None:

--- a/hpedockerplugin/volume_manager.py
+++ b/hpedockerplugin/volume_manager.py
@@ -1256,7 +1256,10 @@ class VolumeManager(object):
 
     def _force_remove_vlun(self, vol, is_snap):
         bkend_vol_name = utils.get_3par_name(vol['id'], is_snap)
-        if self.tgt_bkend_config:
+        # Check if replication is configured and volume is
+        # populated with the RCG
+        if (self.tgt_bkend_config and 'rcg_info' in vol and
+                vol['rcg_info'] is not None):
             if self.tgt_bkend_config.quorum_witness_ip:
                 LOG.info("Peer Persistence setup: Removing VLUNs "
                          "forcefully from remote backend...")


### PR DESCRIPTION
With this change I am able to create both replicated as well as non replicated volume from replication enabled back end in hpe.conf

```
[DEFAULT]
host_etcd_ip_address=192.168.120.134
host_etcd_port_number=23790
hpe3par_username=3paradm
hpe3par_password=wy4a8PYh4IY=
hpe3par_cpg=SHASHI-SEC
hpedockerplugin_driver=hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver
logging=DEBUG
san_ip=192.168.67.5
san_login=3paradm
san_password=wy4a8PYh4IY=
hpe3par_api_url=https://192.168.67.5:8080/api/v1
hpe3par_iscsi_ips=192.168.68.202
replication_device=backend_id:CSSOS-SSA04,replication_mode:synchronous,cpg_map:SHASHI-SEC:SHASHI-PRIM,snap_cpg_map:SHASHI-SEC-SNAP:SHASHI-PRIM-SNAP,hpe3par_username:3paradm,hpe3par_password:wy4a8PYh4IY=,hpe3par_api_url: https://192.168.67.7:8080/api/v1,san_ip: 192.168.67.7,san_login: 3paradm,san_password: wy4a8PYh4IY=, hpe3par_iscsi_ips: 0.0.0.0;192.168.68.204;0.0.0.0;192.168.68.205
```
```
[root@localhost ~]# docker volume create -d hpe --name vol_non_rep -o size=3 -o provisioning=full
vol_non_rep

[root@localhost ~]# docker volume create -d hpe --name vol_rep -o size=3 -o provisioning=full -o replicationGroup=bkd_test
```

Inspecting the volumes:
```
[root@localhost ~]# docker inspect vol_non_rep
[
    {
        "Driver": "hpe",
        "Labels": {},
        "Mountpoint": "/",
        "Name": "vol_non_rep",
        "Options": {
            "provisioning": "full",
            "size": "3"
        },
        "Scope": "global",
        "Status": {
            "volume_detail": {
                "3par_vol_name": "dcv-nf6N2BHNRwGlGlTpRuO4oQ",
                "backend": "DEFAULT",
                "compression": null,
                "cpg": "SHASHI-SEC",
                "domain": "VIVEK_DOMAIN",
                "flash_cache": null,
                "fsMode": null,
                "fsOwner": null,
                "mountConflictDelay": 30,
                "provisioning": "full",
                "size": 3,
                "snap_cpg": "SHASHI-SEC"
            }
        }
    }
]
```

```
[root@localhost ~]# docker inspect vol_rep
[
    {
        "Driver": "hpe",
        "Labels": {},
        "Mountpoint": "/",
        "Name": "vol_rep",
        "Options": {
            "provisioning": "full",
            "replicationGroup": "bkd_test",
            "size": "3"
        },
        "Scope": "global",
        "Status": {
            "rcg_detail": {
                "policies": {
                    "autoFailover": false,
                    "autoRecover": false,
                    "multiTargetPeerPersistence": false,
                    "overPeriodAlert": false,
                    "pathManagement": false
                },
                "rcg_name": "bkd_test",
                "role": "Primary"
            },
            "volume_detail": {
                "3par_vol_name": "dcv-RS2xrLDfQXij5Qm.h8neAw",
                "backend": "DEFAULT",
                "compression": null,
                "cpg": "SHASHI-SEC",
                "domain": "VIVEK_DOMAIN",
                "flash_cache": null,
                "fsMode": null,
                "fsOwner": null,
                "mountConflictDelay": 30,
                "provisioning": "full",
                "secondary_cpg": "SHASHI-PRIM",
                "secondary_snap_cpg": "SHASHI-PRIM-SNAP",
                "size": 3,
                "snap_cpg": "SHASHI-SEC"
            }
        }
    }
]
```

The creation of regular volume in a replicated back end is logged as follows:

> 2019-02-26 08:55:10.011 19 INFO hpe_storage_api [-] 'DEFAULT' is a replication enabled backend. 'replicationGroup' is not specified in the create volume command. Proceeding to create a regular volume withoutremote copy capabilities.^[[00m