### PR TITLE
Update requirements-py3.txt to pick up 4.2.9 version of python-3parclient library

### DIFF
--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -63,7 +63,7 @@ pycrypto==2.6.1
 pyinotify==0.9.6
 PyNaCl==1.2.1
 pyparsing==2.2.0
-python-3parclient==4.2.7
+python-3parclient==4.2.9
 python-dateutil==2.7.3
 python-etcd==0.4.5
 python-lefthandclient==2.1.0


### PR DESCRIPTION
- `python-3parclient==4.2.9` version is required to support iscsi vlan feature on 3PAR.