### PR TITLE
Fix for encrypted password decryption when passphrase length is of 16,24,32 characters

### DIFF
--- a/hpedockerplugin/volume_manager.py
+++ b/hpedockerplugin/volume_manager.py
@@ -2000,6 +2000,9 @@ class VolumeManager(object):
         elif KEY_LEN > 32:
             KEY = key[:32]
 
+        else:
+            KEY = key
+
         return KEY
 
     def _decrypt(self, encrypted, passphrase):


### PR DESCRIPTION
Fix for https://github.com/hpe-storage/python-hpedockerplugin/issues/518