### PR TITLE
Feature: Add RotatingFileHandler for logging

### DIFF
--- a/config/setupcfg.py
+++ b/config/setupcfg.py
@@ -15,7 +15,7 @@
 from hpedockerplugin import configuration as conf
 from hpedockerplugin.hpe import hpe3par_opts as plugin_opts
 from oslo_log import log as logging
-import logging as log1
+import logging as log
 from oslo_config import cfg
 from logging.handlers import RotatingFileHandler
 
@@ -77,14 +77,12 @@ def setup_logging(name, level):
     # Add option to do Log Rotation
     handler = RotatingFileHandler('/etc/hpedockerplugin/3pardcv.log',
                                   maxBytes=10000000, backupCount=100)
-    formatter = log1.Formatter('%(asctime)-12s [%(levelname)s] '
+    formatter = log.Formatter('%(asctime)-12s [%(levelname)s] '
                                '%(name)s [%(thread)d] '
                                '%(threadName)s %(message)s')
 
-
     handler.setFormatter(formatter)
     LOG.logger.addHandler(handler)
-
 
     if level == 'INFO':
         LOG.logger.setLevel(logging.INFO)

--- a/config/setupcfg.py
+++ b/config/setupcfg.py
@@ -15,7 +15,9 @@
 from hpedockerplugin import configuration as conf
 from hpedockerplugin.hpe import hpe3par_opts as plugin_opts
 from oslo_log import log as logging
+import logging as log1
 from oslo_config import cfg
+from logging.handlers import RotatingFileHandler
 
 host_opts = [
     cfg.StrOpt('hpedockerplugin_driver',
@@ -71,6 +73,18 @@ def setup_logging(name, level):
 
     logging.setup(CONF, name)
     LOG = logging.getLogger(None)
+
+    # Add option to do Log Rotation
+    handler = RotatingFileHandler('/etc/hpedockerplugin/3pardcv.log',
+                                  maxBytes=10000000, backupCount=100)
+    formatter = log1.Formatter('%(asctime)-12s [%(levelname)s] '
+                               '%(name)s [%(thread)d] '
+                               '%(threadName)s %(message)s')
+
+
+    handler.setFormatter(formatter)
+    LOG.logger.addHandler(handler)
+
 
     if level == 'INFO':
         LOG.logger.setLevel(logging.INFO)


### PR DESCRIPTION
- Currently the logs of the 3PAR Docker Volume Plugin (Managed plugin) can only be seen via the kernel logging either in `/var/log/messages` (RHEL/CentOS/SLES)  or `/var/log/syslog` (ubuntu)

- Containerized plugin logs can be seen only by `docker logs <container_id_of_plugin>`
- To uniformly write the logging , this change introduces `RotatingFileHandler` way of approach, where the logs are seen on standard folder on the base operating system where the plugin is running , which will be now `/etc/hpedockerplugin/3pardcv.log`