### PR TITLE
Fixed an issue where the directory in which dory installer is downloaded did not exist

### DIFF
--- a/ansible_3par_docker_plugin/install_hpe_3par_volume_driver.yml
+++ b/ansible_3par_docker_plugin/install_hpe_3par_volume_driver.yml
@@ -95,7 +95,9 @@
 - name: Deploy FlexVolume drivers
   hosts: masters,workers,etcd 
   become: root
-
+  environment:
+    http_proxy: "{{ http_proxy | default('') }}"
+    https_proxy: "{{ https_proxy | default('') }}"
   vars:
     driver_path: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/hpe.com~hpe/"
 

--- a/ansible_3par_docker_plugin/install_hpe_3par_volume_driver.yml
+++ b/ansible_3par_docker_plugin/install_hpe_3par_volume_driver.yml
@@ -98,8 +98,6 @@
   environment:
     http_proxy: "{{ http_proxy | default('') }}"
     https_proxy: "{{ https_proxy | default('') }}"
-  vars:
-    driver_path: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/hpe.com~hpe/"
 
   tasks:
     - name: Deploy FlexVolume drivers

--- a/ansible_3par_docker_plugin/tasks/deploy_FlexVolume_driver.yml
+++ b/ansible_3par_docker_plugin/tasks/deploy_FlexVolume_driver.yml
@@ -2,15 +2,15 @@
   - name: Download dory installer
     get_url:
       url: https://github.com/hpe-storage/python-hpedockerplugin/raw/master/dory_installer_v31
-      dest: "{{ driver_path }}"
+      dest: /tmp 
       mode: 0755
 
   - name: Install dory, doryd
     shell: >-
-      yes yes | "{{ driver_path }}/dory_installer_v31"
+      yes yes | /tmp/dory_installer_v31
 
   - name: Remove the dory installer
     file:
-      path: "{{ driver_path }}/dory_installer_v31"
+      path: /tmp/dory_installer_v31
       state: absent
 


### PR DESCRIPTION
Fix for https://github.com/hpe-storage/python-hpedockerplugin/issues/570