### PR TITLE
Feature: File Persona fsMode, fsOwner implementation

### DIFF
--- a/config/create_share_help.txt
+++ b/config/create_share_help.txt
@@ -17,3 +17,10 @@ Create a share in HPE 3PAR using HPE 3PAR volume plug-in for Docker.
 -o size=x                 x is the size of the share in MiB. By default, it is 4TiB
 -o help -o filePersona    When used together, these options display this help content
 -o help=backends -o filePersona  When used togther, these options display status of the backends configured for File Persona
+-o fsOwner=x              x is the user id and group id that should own the root directory  of nfs file share in the form of
+                          [userId:groupId]. Administartor also need to make sure that local user and local group with these
+                          ids are present on 3PAR before trying to mount the created share.
+                          For such shares which has userId and groupId specified, mount will succeed only if users and group
+                          with specified ids are present on 3PAR.
+-o fsMode=x               x is 1 to 4 octal degits that represent the file mode to be applied to the root directory of the
+                          file system.

--- a/config/create_share_help.txt
+++ b/config/create_share_help.txt
@@ -14,13 +14,13 @@ Create a share in HPE 3PAR using HPE 3PAR volume plug-in for Docker.
                             In case this option is not specified, then a default FPG is created with size 64TiB if it
                             doesn't exist. Naming convention for default FPG is DockerFpg_n where n is an integer
                             starting from 0.
--o size=x                 x is the size of the share in MiB. By default, it is 4TiB
+-o size=x                 x is the size of the share in MiB. By default, it is 1TiB
 -o help -o filePersona    When used together, these options display this help content
 -o help=backends -o filePersona  When used togther, these options display status of the backends configured for File Persona
 -o fsOwner=x              x is the user id and group id that should own the root directory  of nfs file share in the form of
-                          [userId:groupId]. Administartor also need to make sure that local user and local group with these
-                          ids are present on 3PAR before trying to mount the created share.
-                          For such shares which has userId and groupId specified, mount will succeed only if users and group
-                          with specified ids are present on 3PAR.
+                            [userId:groupId]. Administartor also need to make sure that local user and local group with these
+                            ids are present on 3PAR before trying to mount the created share.
+                            For such shares which has userId and groupId specified, mount will succeed only if users and
+                            group with specified ids are present on 3PAR.
 -o fsMode=x               x is 1 to 4 octal degits that represent the file mode to be applied to the root directory of the
-                          file system.
+                            file system.

--- a/config/create_share_help.txt
+++ b/config/create_share_help.txt
@@ -11,7 +11,7 @@ Create a share in HPE 3PAR using HPE 3PAR volume plug-in for Docker.
                             For a non-existing FPG x, a new FPG is created using the CPG that is either explicitly
                             specified with '-o cpg' option or configured in hpe.conf.
                             If FPG exists, be it a legacy FPG or Docker managed FPG, share is simply created under it.
-                            In case this option is not specified, then a default FPG is created with size 64TiB if it
+                            In case this option is not specified, then a default FPG is created with size 16TiB if it
                             doesn't exist. Naming convention for default FPG is DockerFpg_n where n is an integer
                             starting from 0.
 -o size=x                 x is the size of the share in MiB. By default, it is 1TiB

--- a/hpedockerplugin/exception.py
+++ b/hpedockerplugin/exception.py
@@ -422,6 +422,10 @@ class FpgAlreadyExists(PluginException):
     message = _("FPG already exists: %(reason)s")
 
 
+class UserGroupNotFoundOn3PAR(PluginException):
+    message = _("fsusergroup or fsuser doesn't exist on 3PAR: (reason)s")
+
+
 class SetQuotaFailed(PluginException):
     message = _("Set quota failed: %(reason)s")
 

--- a/hpedockerplugin/exception.py
+++ b/hpedockerplugin/exception.py
@@ -423,7 +423,7 @@ class FpgAlreadyExists(PluginException):
 
 
 class UserGroupNotFoundOn3PAR(PluginException):
-    message = _("fsusergroup or fsuser doesn't exist on 3PAR: (reason)s")
+    message = _("fsusergroup or fsuser doesn't exist on 3PAR: %(reason)s")
 
 
 class SetQuotaFailed(PluginException):

--- a/hpedockerplugin/file_manager.py
+++ b/hpedockerplugin/file_manager.py
@@ -624,8 +624,6 @@ class FileManager(object):
             if fUser or fGroup or fMode:
                 LOG.info("Inside fUser or fGroup or fMode")
                 is_first_call = True
-                fUName = None
-                fGName = None
                 try:
                     fUName, fGName = self._hpeplugin_driver.usr_check(fUser,
                                                                       fGroup)

--- a/hpedockerplugin/file_manager.py
+++ b/hpedockerplugin/file_manager.py
@@ -630,7 +630,7 @@ class FileManager(object):
                     if fUName is None or fGName is None:
                         msg = ("Either user or group does not exist on 3PAR "
                                "Please create local users and group with "
-                               "required user id and group is")
+                               "required user id and group id")
                         LOG.error(msg)
                         raise exception.UserGroupNotFoundOn3PAR(msg)
                 except exception.UserGroupNotFoundOn3PAR as ex:

--- a/hpedockerplugin/file_manager.py
+++ b/hpedockerplugin/file_manager.py
@@ -1,7 +1,9 @@
 import copy
 import json
 import sh
+from sh import chmod
 import six
+import os
 from threading import Thread
 
 from oslo_log import log as logging
@@ -549,7 +551,21 @@ class FileManager(object):
         if 'status' in share:
             if share['status'] == 'FAILED':
                 LOG.error("Share not present")
-
+        fUser = None
+        fGroup = None
+        fMode = None
+        fUName = None
+        fGName = None
+        is_first_call = False
+        if share['fsOwner']:
+            fOwner = share['fsOwner'].split(':')
+            fUser = int(fOwner[0])
+            fGroup = int(fOwner[1])
+        if share['fsMode']:
+            try:
+                fMode = int(share['fsMode'])
+            except ValueError:
+                fMode = share['fsMode']
         fpg = share['fpg']
         vfs = share['vfs']
         file_store = share['name']
@@ -604,12 +620,24 @@ class FileManager(object):
                 }
             }
             share['path_info'] = node_mnt_info
+            if fUser or fGroup or fMode:
+                is_first_call = True
+                fUName, fGName = self._hpeplugin_driver.usr_check(fUser,
+                                                                  fGroup)
 
         self._create_mount_dir(mount_dir)
         LOG.info("Mounting share path %s to %s" % (share_path, mount_dir))
         sh.mount('-t', 'nfs', share_path, mount_dir)
         LOG.debug('Device: %(path)s successfully mounted on %(mount)s',
                   {'path': share_path, 'mount': mount_dir})
+        if is_first_call:
+            os.chown(mount_dir, fUser, fGroup)
+            try:
+                int(fMode)
+                chmod(fMode, mount_dir)
+            except ValueError:
+                self._hpeplugin_driver.set_ACL(fMode, mount_dir, fUName,
+                                               fGName)
 
         self._etcd.save_share(share)
         response = json.dumps({u"Err": '', u"Name": share_name,

--- a/hpedockerplugin/hpe/hpe_3par_mediator.py
+++ b/hpedockerplugin/hpe/hpe_3par_mediator.py
@@ -1033,6 +1033,49 @@ class HPE3ParMediator(object):
         finally:
             self._wsapi_logout()
 
+    def set_ACL(fUName, fGName, fMode):
+        LOG.info("Inside set ACL call but temperory not making"
+                 " any rest call.")
+
+    def _check_usr_grp_existence(fUserOwner, res_cmd):
+        fuserowner = str(fUserOwner)
+        uname_index = 0
+        uid_index = 1
+        user_name = None
+        first_line = res_cmd[0]
+        first_line_list = first_line.split(',')
+        for index, value in enumerate(first_line_list):
+            if value == 'Username':
+                uname_index = index
+            if value == 'UID':
+                uid_index = index
+        res_len = len(res_cmd)
+        end_index = res_len - 2
+        for line in res_cmd[1:end_index]:
+            line_list = line.split(',')
+            if fuserowner == line_list[uid_index]:
+                user_name = line_list[uname_index]
+                return user_name
+        if user_name is None:
+            msg = ("User or Group not found on 3PAR")
+            LOG.error(msg)
+            raise exception.UserGroupNotFoundOn3PAR(msg=msg)
+
+    def usr_check(self, fUser, fGroup):
+        cmd1 = ['showfsuser']
+        cmd2 = ['showfsgroup']
+        try:
+            res_cmd1 = self._client._run(cmd1)
+            f_user_name = self._check_usr_grp_existence(fUser, res_cmd1)
+            res_cmd2 = self._client._run(cmd2)
+            f_group_name = self._check_usr_grp_existence(fGroup, res_cmd2)
+            return f_user_name, f_group_name
+        except hpeexceptions.SSHException as ex:
+            msg = (_('Failed to get the corresponding user and group name '
+                     'reason is %s:') % six.text_type(ex))
+            LOG.error(msg)
+            raise exception.ShareBackendException(msg=msg)
+
     def add_client_ip_for_share(self, share_id, client_ip):
         uri = '/fileshares/%s' % share_id
         body = {

--- a/hpedockerplugin/hpe/hpe_3par_mediator.py
+++ b/hpedockerplugin/hpe/hpe_3par_mediator.py
@@ -1065,10 +1065,10 @@ class HPE3ParMediator(object):
         cmd2 = ['showfsgroup']
         try:
             LOG.info("Now will execute first cmd1")
-            cmd1 = cmd1.append('\r')
+            cmd1.append('\r')
             res_cmd1 = self._client._run(cmd1)
             f_user_name = self._check_usr_grp_existence(fUser, res_cmd1)
-            cmd2 = cmd2.append('\r')
+            cmd2.append('\r')
             res_cmd2 = self._client._run(cmd2)
             f_group_name = self._check_usr_grp_existence(fGroup, res_cmd2)
             return f_user_name, f_group_name

--- a/hpedockerplugin/hpe/share.py
+++ b/hpedockerplugin/hpe/share.py
@@ -5,7 +5,8 @@ MAX_SHARES_PER_FPG = 16
 
 
 def create_metadata(backend, cpg, fpg, share_name, size,
-                    readonly=False, nfs_options=None, comment=''):
+                    readonly=False, nfs_options=None, comment='',
+                    fsMode=None, fsOwner=None):
     return {
         'id': str(uuid.uuid4()),
         'backend': backend,
@@ -19,4 +20,6 @@ def create_metadata(backend, cpg, fpg, share_name, size,
         'protocol': 'nfs',
         'clientIPs': [],
         'comment': comment,
+        'fsMode': fsMode,
+        'fsOwner': fsowner,
     }

--- a/hpedockerplugin/hpe/share.py
+++ b/hpedockerplugin/hpe/share.py
@@ -21,5 +21,5 @@ def create_metadata(backend, cpg, fpg, share_name, size,
         'clientIPs': [],
         'comment': comment,
         'fsMode': fsMode,
-        'fsOwner': fsowner,
+        'fsOwner': fsOwner,
     }

--- a/hpedockerplugin/request_context.py
+++ b/hpedockerplugin/request_context.py
@@ -299,7 +299,6 @@ class FileRequestContextBuilder(RequestContextBuilder):
             )
         cpg = self._get_str_option(options, 'cpg', config.hpe3par_cpg[0])
         fpg = self._get_str_option(options, 'fpg', None)
-        # swapnil
         fsMode = self._get_str_option(options, 'fsMode', None)
         fsOwner = self._get_str_option(options, 'fsOwner', None)
         if fsMode:

--- a/hpedockerplugin/request_context.py
+++ b/hpedockerplugin/request_context.py
@@ -337,7 +337,7 @@ class FileRequestContextBuilder(RequestContextBuilder):
         share_details = share.create_metadata(backend, cpg, fpg, name, size,
                                               readonly=readonly,
                                               nfs_options=nfs_options,
-                                              comment=comment, fsMOde=fsMode,
+                                              comment=comment, fsMode=fsMode,
                                               fsOwner=fsOwner)
         LOG.info("_create_share_req_params: %s" % share_details)
         return share_details
@@ -346,7 +346,7 @@ class FileRequestContextBuilder(RequestContextBuilder):
         LOG.info("_create_share_req_ctxt: Entering...")
         valid_opts = ('backend', 'filePersona', 'cpg', 'fpg',
                       'size', 'readonly', 'nfsOptions', 'comment',
-                      'mountConflictDelay')
+                      'mountConflictDelay', 'fsMode', 'fsOwner')
         mandatory_opts = ('filePersona',)
         self._validate_opts("create share", contents, valid_opts,
                             mandatory_opts)

--- a/hpedockerplugin/request_context.py
+++ b/hpedockerplugin/request_context.py
@@ -165,7 +165,6 @@ class RequestContextBuilder(object):
                   "format and values to be passed in help"
             LOG.error(msg)
             raise exception.InvalidInput(reason=msg)
-        
         vtype = type_flag_perm[0]
         if vtype not in valid_type:
             msg = "Incorrect value passed for type of a mode, please check "\
@@ -188,7 +187,7 @@ class RequestContextBuilder(object):
         vperm = list(set(list(type_flag_perm[2])))
         if len(vperm) < passed_vperm_len:
             msg = "Duplicate characters for given permission are passed. "\
-                  "Please correct the passed permissions for fsMode".
+                  "Please correct the passed permissions for fsMode."
             LOG.error(msg)
             raise exception.InvalidInput(reason=msg)
         if set(vperm) - set(valid_perm):
@@ -210,7 +209,7 @@ class RequestContextBuilder(object):
     @staticmethod
     def _is_valid_octal_num(fsMode):
         return re.match('^0[0-7]{3}$', fsMode)
-    
+
     def _validate_fsMode(self, fsMode):
         is_valid_fs_mode = True
         if ':' in fsMode:
@@ -300,10 +299,9 @@ class FileRequestContextBuilder(RequestContextBuilder):
             )
         cpg = self._get_str_option(options, 'cpg', config.hpe3par_cpg[0])
         fpg = self._get_str_option(options, 'fpg', None)
-        #swapnil
+        # swapnil
         fsMode = self._get_str_option(options, 'fsMode', None)
         fsOwner = self._get_str_option(options, 'fsOwner', None)
-        
         if fsMode:
             self._validate_fsMode(fsMode)
 


### PR DESCRIPTION
This  commit will change the directory permission and can give access to particular user and a group for a directory.

Suppose if an administrator wants to give access to share acl_fshare1 to user with uid 1000 and  group with group id 1000 also, permission of directory should be set to 754 then these are the steps he/she needs to follow:
1. Create local user and local group associated with File Persona on 3PAR.
2. Create share with 3PAR with docker volume create command 
docker volume create -d hpe --name  acl_fshare1  -o filePersona -o fpg=<fpg_name> -o fsOwner="1000:1000" -o fsMode="0754"
Here 0 before the mode bits is mandatory.
3. docker run -it -v acl_share1:/data1 --user 1000:1000 --rm busybox /bin/sh

Verification:
After the mount user can see the id and permissions associated with data1 directory and permissions for this data1 directory by executing 'id' and 'ls -ltr'

also on 3PAR same can be checked with below command:

showfshare nfs -dirperm -fstore <file_store> -vfs <vfs_Name> <file_share_name>
