### PR TITLE
File share size is now expected in GiB instead of MiB

### DIFF
--- a/config/create_share_help.txt
+++ b/config/create_share_help.txt
@@ -14,7 +14,7 @@ Create a share in HPE 3PAR using HPE 3PAR volume plug-in for Docker.
                             In case this option is not specified, then a default FPG is created with size 16TiB if it
                             doesn't exist. Naming convention for default FPG is DockerFpg_n where n is an integer
                             starting from 0.
--o size=x                 x is the size of the share in MiB. By default, it is 1TiB
+-o size=x                 x is the size of the share in GiB. By default, it is 1TiB
 -o help -o filePersona    When used together, these options display this help content
 -o help=backends -o filePersona  When used togther, these options display status of the backends configured for File Persona
 -o fsOwner=x              x is the user id and group id that should own the root directory  of nfs file share in the form of

--- a/config/create_share_help.txt
+++ b/config/create_share_help.txt
@@ -14,7 +14,7 @@ Create a share in HPE 3PAR using HPE 3PAR volume plug-in for Docker.
                             In case this option is not specified, then a default FPG is created with size 16TiB if it
                             doesn't exist. Naming convention for default FPG is DockerFpg_n where n is an integer
                             starting from 0.
--o size=x                 x is the size of the share in GiB. By default, it is 1TiB
+-o size=x                 x is the size of the share in GiB. By default, it is 1024 GiB.
 -o help -o filePersona    When used together, these options display this help content
 -o help=backends -o filePersona  When used togther, these options display status of the backends configured for File Persona
 -o fsOwner=x              x is the user id and group id that should own the root directory  of nfs file share in the form of

--- a/hpedockerplugin/request_context.py
+++ b/hpedockerplugin/request_context.py
@@ -308,7 +308,7 @@ class FileRequestContextBuilder(RequestContextBuilder):
             self._validate_fsOwner(fsOwner)
 
         # Default share size or quota in MiB which is 1TiB
-        size = self._get_int_option(options, 'size', 1 * 1024 * 1024)
+        size = self._get_int_option(options, 'size', 1 * 1024) * 1024
 
         # TODO: This check would be required when VFS needs to be created.
         # NOT HERE


### PR DESCRIPTION
File share size is now expected in GiB instead of MiB
Default share size and FPG size remains unchanged.

This closes issue #613 