### PR TITLE
Added conditions to handle the strict keywords for single configuration

### DIFF
--- a/ansible_3par_docker_plugin/tasks/install_prerequisites_on_all.yml
+++ b/ansible_3par_docker_plugin/tasks/install_prerequisites_on_all.yml
@@ -49,7 +49,7 @@
       set_mixed == false and 
       (INVENTORY['DEFAULT_FILE'] is defined or INVENTORY['DEFAULT_BLOCK'] is defined)
 
-  - name: Fail when DEFAULT backend is having file driver and DEFAULT_FILE backend with file driver is defined 
+  - name: Fail when DEFAULT and DEFAULT_FILE backend defined with file driver
     fail:
       msg: "DEFAULT_FILE backend should not be present when DEFAULT backend has filedriver"
     with_items:
@@ -59,7 +59,7 @@
       INVENTORY['DEFAULT']['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_file.HPE3PARFileDriver' and 
       INVENTORY['DEFAULT_FILE'] is defined
 
-  - name: Fail when DEFAULT backend is having block driver and DEFAULT_BLOCK backend with block driver is defined 
+  - name: Fail when DEFAULT and DEFAULT_BLOCK backend is defined with block driver
     fail:
       msg: "DEFAULT_BLOCK backend should not be present when DEFAULT backend has blockdriver"
     with_items:

--- a/ansible_3par_docker_plugin/tasks/install_prerequisites_on_all.yml
+++ b/ansible_3par_docker_plugin/tasks/install_prerequisites_on_all.yml
@@ -40,7 +40,7 @@
       ('hpedockerplugin.hpe.hpe_3par_file.HPE3PARFileDriver'  in  my_driver_list and 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' in my_driver_list) or 
       ('hpedockerplugin.hpe.hpe_3par_file.HPE3PARFileDriver'  in  my_driver_list and 'hpedockerplugin.hpe.hpe_3par_fc.HPE3PARFCDriver' in  my_driver_list )    
      
-  - name: Fail when DEFAULT_FILE backend and DEFAULT_BLOCK is defined with single configuration 
+  - name: Fail when DEFAULT_FILE and DEFAULT_BLOCK backend is defined with single configuration 
     fail:
       msg: "DEFAULT_FILE and DEFAULT_BLOCK backends should not be present in single configuration"
     with_items:
@@ -49,7 +49,7 @@
       set_mixed == false and 
       (INVENTORY['DEFAULT_FILE'] is defined or INVENTORY['DEFAULT_BLOCK'] is defined)
 
-  - name: Fail when DEFAULT and DEFAULT_FILE backend defined with file driver
+  - name: Fail when DEFAULT and DEFAULT_FILE backend is defined with file driver
     fail:
       msg: "DEFAULT_FILE backend should not be present when DEFAULT backend has filedriver"
     with_items:

--- a/ansible_3par_docker_plugin/tasks/install_prerequisites_on_all.yml
+++ b/ansible_3par_docker_plugin/tasks/install_prerequisites_on_all.yml
@@ -6,7 +6,7 @@
 
   - name: Initialize the flag for mixed configuration
     set_fact:
-      set_mixed: ''  
+      set_mixed: 'false'  
  
   - name: Initialize an empty list for backend drivers
     set_fact:
@@ -19,7 +19,7 @@
       - "{{ INVENTORY.keys()}}"
     register: my_driver_list  
     
-  - name:  Initialize valid driver list
+  - name: Initialize valid driver list
     set_fact: 
       default_drivers:
       - hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver
@@ -40,6 +40,36 @@
       ('hpedockerplugin.hpe.hpe_3par_file.HPE3PARFileDriver'  in  my_driver_list and 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' in my_driver_list) or 
       ('hpedockerplugin.hpe.hpe_3par_file.HPE3PARFileDriver'  in  my_driver_list and 'hpedockerplugin.hpe.hpe_3par_fc.HPE3PARFCDriver' in  my_driver_list )    
      
+  - name: Fail when DEFAULT_FILE backend and DEFAULT_BLOCK is defined with single configuration 
+    fail:
+      msg: "DEFAULT_FILE and DEFAULT_BLOCK backends should not be present in single configuration"
+    with_items:
+      - "{{ INVENTORY.keys()}}" 
+    when: >-
+      set_mixed == false and 
+      (INVENTORY['DEFAULT_FILE'] is defined or INVENTORY['DEFAULT_BLOCK'] is defined)
+
+  - name: Fail when DEFAULT backend is having file driver and DEFAULT_FILE backend with file driver is defined 
+    fail:
+      msg: "DEFAULT_FILE backend should not be present when DEFAULT backend has filedriver"
+    with_items:
+      - "{{ INVENTORY.keys()}}" 
+    when: >-
+      set_mixed == true and 
+      INVENTORY['DEFAULT']['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_file.HPE3PARFileDriver' and 
+      INVENTORY['DEFAULT_FILE'] is defined
+
+  - name: Fail when DEFAULT backend is having block driver and DEFAULT_BLOCK backend with block driver is defined 
+    fail:
+      msg: "DEFAULT_BLOCK backend should not be present when DEFAULT backend has blockdriver"
+    with_items:
+      - "{{ INVENTORY.keys()}}" 
+    when: >-
+      set_mixed == true and 
+      (INVENTORY['DEFAULT']['hpedockerplugin_driver'] == 'hpedockerplugin.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver' or 
+      INVENTORY['DEFAULT']['hpedockerplugin_driver']  == 'hpedockerplugin.hpe.hpe_3par_fc.HPE3PARFCDriver')
+      and INVENTORY['DEFAULT_BLOCK'] is defined
+    
   - name: Fail when DEFAULT backend driver is block and DEFAULT_FILE backend is not present in mixed configuration
     fail :
       msg: "DEFAULT_FILE backend is not present in mixed configuration"


### PR DESCRIPTION
Hi Sneha/Imran,
Can you please review the PR.
Added condition in installer to handle the strict keywords as DEFAULT_FILE and DEFAULT_BLOCK in single configuration also.(As per fix added for issue #621)
If DEFAULT is mentioned as filedriver then there should not be DEFAULT_FILE backend and same for block.

Regards
Bhagyashree Sarawate
[installer_logs.txt](https://github.com/hpe-storage/python-hpedockerplugin/files/3226989/installer_logs.txt)

