### PR TITLE
Added data dir parameter while creating etcd container

### DIFF
--- a/ansible_3par_docker_plugin/README.md
+++ b/ansible_3par_docker_plugin/README.md
@@ -63,6 +63,9 @@ These playbooks perform the following tasks on the Master/Worker nodes as define
       | ```etcd_client_port_1```  | Yes  | 23790 |
       | ```etcd_client_port_2```  | Yes  | 40010 |
       
+  - The Etcd data directory for backup and restore can be modified in [etcd cluster properties](/ansible_3par_docker_plugin/properties/etcd_cluster_properties.yml)
+      e.g. etcd_data_directory=/var/lib/etcd
+    
     > **Note:** Please ensure that the ports specified above are unoccupied before installation. If the ports are not available on a particular node, etcd installation will fail.
     
     > **Limitation:** The installer, in the current state does not have the capability to add or remove nodes in the etcd cluster. In case an etcd node is not responding or goes down, it is beyond the current scope to admit it back into the cluster. Please follow the [etcd documentation](https://coreos.com/etcd/docs/latest/etcd-live-cluster-reconfiguration.html) to do so manually.

--- a/ansible_3par_docker_plugin/install_standalone_hpe_3par_volume_driver.yml
+++ b/ansible_3par_docker_plugin/install_standalone_hpe_3par_volume_driver.yml
@@ -130,6 +130,7 @@
         ETCD_LISTEN_PEER_URLS: "{{ etcd_listen_peer_urls }}"
         ETCD_INITIAL_CLUSTER: "etcd0=http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ etcd_peer_port }}"
         ETCD_INITIAL_CLUSTER_TOKEN: "{{ etcd_initial_cluster_token }}"
+        ETCD_DATA_DIR: "{{ etcd_data_dir }}"
         ETCD_INITIAL_CLUSTER_STATE: "{{ etcd_initial_cluster_state }}"
       restart_policy: always
     become: yes

--- a/ansible_3par_docker_plugin/properties/etcd_cluster_properties.yml
+++ b/ansible_3par_docker_plugin/properties/etcd_cluster_properties.yml
@@ -20,6 +20,7 @@ etcd_client_port_1: 23790
 etcd_client_port_2: 40010
 etcd_url_scheme: http
 etcd_peer_port: 23800
+etcd_data_directory: /var/lib/etcd
 
 etcd_name: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
 etcd_advertise_client_url_1: "{{ etcd_url_scheme }}://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ etcd_client_port_1 }}"
@@ -29,4 +30,5 @@ etcd_listen_client_url_2: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_port_2
 etcd_initial_advertise_peer_urls: "{{ etcd_url_scheme }}://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ etcd_peer_port }}"
 etcd_listen_peer_urls: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_peer_port }}"
 etcd_initial_cluster_token: etcd-cluster-1
+etcd_data_dir: "{{etcd_data_directory}}"
 etcd_initial_cluster_state: "new"

--- a/ansible_3par_docker_plugin/tasks/create_etcd_container.yml
+++ b/ansible_3par_docker_plugin/tasks/create_etcd_container.yml
@@ -30,5 +30,6 @@
         ETCD_LISTEN_PEER_URLS: "{{ etcd_listen_peer_urls }}"
         ETCD_INITIAL_CLUSTER: "{{ etcd_initial_cluster[1:] }}" 
         ETCD_INITIAL_CLUSTER_TOKEN: "{{ etcd_initial_cluster_token }}"
+        ETCD_DATA_DIR: "{{ etcd_data_dir }}"
         ETCD_INITIAL_CLUSTER_STATE: "{{ etcd_initial_cluster_state }}"
       restart_policy: always


### PR DESCRIPTION
Hi Sneha/William,
Added the ETCD_DATA_DIR parameter while creating the etcd container
Please review.
Verified whether the ETCD_DATA_DIR is set after running the playbook as follows:

[root@csimbe06-b13 ansible_3par_docker_plugin]# docker ps -a
CONTAINER ID        IMAGE                                          COMMAND                  CREATED             STATUS                   PORTS                                                                                                             NAMES
6888fc2fa394        hpestorage/legacyvolumeplugin:3.2-prerelease   "/bin/sh -c ./pluginâ¦"   6 minutes ago       Up 6 minutes                                                                                                                               plugin_container
b04e082ca756        quay.io/coreos/etcd:v2.2.0                     "/etcd"                  7 minutes ago       Up 7 minutes             2379-2380/tcp, 4001/tcp, 0.0.0.0:23790->23790/tcp, 0.0.0.0:23800->23800/tcp, 7001/tcp, 0.0.0.0:40010->40010/tcp   etcd
809a2091a15a        hello-world                                    "/hello"                 5 weeks ago         Exited (0) 5 weeks ago                                                                                                                     epic_feynman



[root@csimbe06-b13 ansible_3par_docker_plugin]# docker exec -it b04e082ca756 /etcd
2019-06-10 09:25:01.639397 I | flags: recognized and used environment variable ETCD_ADVERTISE_CLIENT_URLS=http://10.50.0.160:23790,http://10.50.0.160:40010
2019-06-10 09:25:01.639466 I | flags: recognized and used environment variable ETCD_DATA_DIR=/var/lib/etcd
2019-06-10 09:25:01.639491 I | flags: recognized and used environment variable ETCD_INITIAL_ADVERTISE_PEER_URLS=http://10.50.0.160:23800
2019-06-10 09:25:01.639502 I | flags: recognized and used environment variable ETCD_INITIAL_CLUSTER=etcd0=http://10.50.0.160:23800
2019-06-10 09:25:01.639539 I | flags: recognized and used environment variable ETCD_INITIAL_CLUSTER_STATE=new
2019-06-10 09:25:01.639580 I | flags: recognized and used environment variable ETCD_INITIAL_CLUSTER_TOKEN=etcd-cluster-1
2019-06-10 09:25:01.639598 I | flags: recognized and used environment variable ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:23790,http://0.0.0.0:40010
2019-06-10 09:25:01.639610 I | flags: recognized and used environment variable ETCD_LISTEN_PEER_URLS=http://0.0.0.0:23800
2019-06-10 09:25:01.639632 I | flags: recognized and used environment variable ETCD_NAME=etcd0
2019-06-10 09:25:01.639724 I | etcdmain: etcd Version: 2.2.0
2019-06-10 09:25:01.639739 I | etcdmain: Git SHA: e4561dd
2019-06-10 09:25:01.639747 I | etcdmain: Go Version: go1.5
2019-06-10 09:25:01.639756 I | etcdmain: Go OS/Arch: linux/amd64
2019-06-10 09:25:01.639765 I | etcdmain: setting maximum number of CPUs to 32, total number of available CPUs is 32
2019-06-10 09:25:01.639850 N | etcdmain: the server is already initialized as member before, starting as etcd member...
2019-06-10 09:25:01.640081 C | etcdmain: listen tcp 0.0.0.0:23800: bind: address already in use
