### PR TITLE
Fix chcon error -- Issue #640

### DIFF
--- a/hpedockerplugin/file_manager.py
+++ b/hpedockerplugin/file_manager.py
@@ -754,7 +754,11 @@ class FileManager(object):
 
         self._create_mount_dir(mount_dir)
         LOG.info("Mounting share path %s to %s" % (share_path, mount_dir))
-        sh.mount('-t', 'nfs', share_path, mount_dir)
+        if utils.is_host_os_rhel():
+            sh.mount('-o', 'context="system_u:object_r:nfs_t:s0"',
+                     '-t', 'nfs', share_path, mount_dir)
+        else:
+            sh.mount('-t', 'nfs', share_path, mount_dir)
         LOG.debug('Device: %(path)s successfully mounted on %(mount)s',
                   {'path': share_path, 'mount': mount_dir})
 

--- a/hpedockerplugin/hpe/hpe_3par_common.py
+++ b/hpedockerplugin/hpe/hpe_3par_common.py
@@ -206,8 +206,8 @@ class HPE3PARCommon(object):
                  {"common_ver": self.VERSION,
                   "rest_ver": hpe3parclient.get_version_string()})
 
-        self.client_login()
         try:
+            self.client_login()
             cpg_names = self.src_bkend_config.hpe3par_cpg
             for cpg_name in cpg_names:
                 self.validate_cpg(cpg_name)

--- a/hpedockerplugin/hpe/utils.py
+++ b/hpedockerplugin/hpe/utils.py
@@ -17,6 +17,7 @@
 import six
 import string
 import uuid
+import platform
 
 from Crypto.Cipher import AES
 from Crypto.Random import random
@@ -154,6 +155,14 @@ def get_3par_rcg_name(id):
 def get_remote3par_rcg_name(id, array_id):
     return get_3par_rcg_name(id) + ".r" + (
         six.text_type(array_id))
+
+
+def is_host_os_rhel():
+    platform_type = list(platform.linux_distribution())
+    if 'Red Hat Enterprise Linux Server' in platform_type:
+        return True
+    else:
+        return False
 
 
 class PasswordDecryptor(object):


### PR DESCRIPTION
Fix for issue #640 

Issue summary:
On RHEL with SElinux enabled configuration, chcon command as part of dory mount process fails on the mount point of a NFS share.

```
Debug: 2019/06/03 16:06:48 flexvol.go:509: doMount: bind mounted dockerPath=/opt/hpe/data/hpedocker-bbb2ba9d-85eb-11e9-b4ea-f40343a90200 at flexvolPath=/var/lib/origin/openshift.local.volumes/pods/bbb2ba9d-85eb-11e9-b4ea-f40343a90200/volumes/hpe.com~hpe/sc-personafile-3f5e1c79-85eb-11e9-b4ea-f40343a90200
Debug: 2019/06/03 16:06:48 cmd.go:33: ExecCommandOutput called with selinuxenabled[]
Debug: 2019/06/03 16:06:48 cmd.go:49: out :
Debug: 2019/06/03 16:06:48 selinux.go:32: selinuxenabled returned 0 and err=<nil>
Debug: 2019/06/03 16:06:48 selinux.go:43: Chcon about to change context of /opt/hpe/data/hpedocker-bbb2ba9d-85eb-11e9-b4ea-f40343a90200 to svirt_sandbox_file_t
Debug: 2019/06/03 16:06:48 cmd.go:33: ExecCommandOutput called with chcon[-t svirt_sandbox_file_t /opt/hpe/data/hpedocker-bbb2ba9d-85eb-11e9-b4ea-f40343a90200]
Debug: 2019/06/03 16:06:48 cmd.go:49: out :chcon: failed to change context of ‘/opt/hpe/data/hpedocker-bbb2ba9d-85eb-11e9-b4ea-f40343a90200’ to ‘system_u:object_r:svirt_sandbox_file_t:s0’: Operation not supported
Debug: 2019/06/03 16:06:48 cmd.go:49: out :
Info : 2019/06/03 16:06:48 dory.go:100: [13807] reply  : mount [/var/lib/origin/openshift.local.volumes/pods/bbb2ba9d-85eb-11e9-b4ea-f40343a90200/volumes/hpe.com~hpe/sc-personafile-3f5e1c79-85eb-11e9-b4ea-f40343a90200 {"filePersona":"","fpg":"DockerFpg_0","kubernetes.io/fsType":"","kubernetes.io/pod.name":"pod-filepersona","kubernetes.io/pod.namespace":"default","kubernetes.io/pod.uid":"bbb2ba9d-85eb-11e9-b4ea-f40343a90200","kubernetes.io/pvOrVolumeName":"sc-personafile-3f5e1c79-85eb-11e9-b4ea-f40343a90200","kubernetes.io/readwrite":"rw","kubernetes.io/serviceAccount.name":"default","name":"sc-personafile-3f5e1c79-85eb-11e9-b4ea-f40343a90200"}]: {"status":"Failure","message":"rc=1"}

```
Fix is to set `-o context="system_u:object_r:nfs_t:s0"` as part of the mount command via the plugin itself.