### PR TITLE
Fix issue #672

### DIFF
--- a/hpedockerplugin/fileutil.py
+++ b/hpedockerplugin/fileutil.py
@@ -142,8 +142,10 @@ def check_if_mounted(src, tgt):
         # So, we need to check for the file existence of both src/tgt folders
         if check_if_file_exists(src) and \
                 check_if_file_exists(tgt):
+            LOG.info('SRC and TGT is present')
             return True
         else:
+            LOG.info('SRC %s or TGT %s does not exist' % (src, tgt))
             return False
     # If there is a mountpoint meeting the criteria then
     # everything is ok, return True
@@ -152,8 +154,7 @@ def check_if_mounted(src, tgt):
 
 
 def check_if_file_exists(path):
-    return os.path.isfile(path) \
-        or os.path.isdir(path)
+    return os.path.exists(path)
 
 
 def umount_dir(tgt):


### PR DESCRIPTION
Rework fix for issue #672 

For some reason os.path.isfile(path) and os.path.isdir(path) returns False, even though the file/dir exists
Analysis
```
docker@csosbe03b10:~/ansible_playbooks$ python
Python 2.7.12 (default, Dec  4 2017, 14:50:18)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.path.isfile('/dev/dm-34')
False
>>> os.path.isdir('/dev/dm-34')
False
>>> os.path.islink('/dev/dm-34')
False
>>> os.path.exists('/dev/dm-34')
True
>>> os.path.exists('/opt/hpe/data/hpedocker-dm-uuid-mpath-360002ac0000000000001db570001db31')
True
>>> quit()
```