### PR TITLE
Modified dory installer version as v32 and modified documentation in manual installation document

### DIFF
--- a/ansible_3par_docker_plugin/README.md
+++ b/ansible_3par_docker_plugin/README.md
@@ -54,6 +54,7 @@ These playbooks perform the following tasks on the Master/Worker nodes as define
       | ```hpe3par_iscsi_ips```  | No  | No default value | Comma separated iscsi IPs. If not provided, all iscsi IPs will be read from the array and populated in hpe.conf |
       | ```vlan_tag```  | No  | False | Populates the iscsi_ips which are vlan tagged, only applicable if ```hpe3par_iscsi_ips``` is not specified |
       | ```replication_device```  | No  | No default value | Replication backend properties |
+      | ```dory_installer_version```  | Yes  | dory_installer_v32 | Required for Openshift/Kubernetes setup.Dory installer version, supported versions are dory_installer_v31,dory_installer_v32 |
       
   - The Etcd ports can be modified in [etcd cluster properties](/ansible_3par_docker_plugin/properties/etcd_cluster_properties.yml) as follows:
   

--- a/ansible_3par_docker_plugin/README.md
+++ b/ansible_3par_docker_plugin/README.md
@@ -54,7 +54,7 @@ These playbooks perform the following tasks on the Master/Worker nodes as define
       | ```hpe3par_iscsi_ips```  | No  | No default value | Comma separated iscsi IPs. If not provided, all iscsi IPs will be read from the array and populated in hpe.conf |
       | ```vlan_tag```  | No  | False | Populates the iscsi_ips which are vlan tagged, only applicable if ```hpe3par_iscsi_ips``` is not specified |
       | ```replication_device```  | No  | No default value | Replication backend properties |
-      | ```dory_installer_version```  | Yes  | dory_installer_v32 | Required for Openshift/Kubernetes setup.Dory installer version, supported versions are dory_installer_v31,dory_installer_v32 |
+      | ```dory_installer_version```  | No  | dory_installer_v32 | Required for Openshift/Kubernetes setup.Dory installer version, supported versions are dory_installer_v31,dory_installer_v32 |
       
   - The Etcd ports can be modified in [etcd cluster properties](/ansible_3par_docker_plugin/properties/etcd_cluster_properties.yml) as follows:
   

--- a/ansible_3par_docker_plugin/README.md
+++ b/ansible_3par_docker_plugin/README.md
@@ -54,7 +54,7 @@ These playbooks perform the following tasks on the Master/Worker nodes as define
       | ```hpe3par_iscsi_ips```  | No  | No default value | Comma separated iscsi IPs. If not provided, all iscsi IPs will be read from the array and populated in hpe.conf |
       | ```vlan_tag```  | No  | False | Populates the iscsi_ips which are vlan tagged, only applicable if ```hpe3par_iscsi_ips``` is not specified |
       | ```replication_device```  | No  | No default value | Replication backend properties |
-      | ```dory_installer_version```  | No  | dory_installer_v32 | Required for Openshift/Kubernetes setup.Dory installer version, supported versions are dory_installer_v31,dory_installer_v32 |
+      | ```dory_installer_version```  | No  | dory_installer_v32 | Required for Openshift/Kubernetes setup. Dory installer version, supported versions are dory_installer_v31, dory_installer_v32 |
       
   - The Etcd ports can be modified in [etcd cluster properties](/ansible_3par_docker_plugin/properties/etcd_cluster_properties.yml) as follows:
   

--- a/ansible_3par_docker_plugin/properties/plugin_configuration_properties_sample.yml
+++ b/ansible_3par_docker_plugin/properties/plugin_configuration_properties_sample.yml
@@ -13,6 +13,9 @@ INVENTORY:
 
     # Plugin version - Required only in DEFAULT backend
     volume_plugin: hpestorage/legacyvolumeplugin:3.0
+    # Dory installer version - Required for Openshift/Kubernetes setup
+    # Supported versions are dory_installer_v31, dory_installer_v32
+    dory_installer_version: dory_installer_v32
 
 #Optional Parameters------------------------------------------------------------------------------------
 

--- a/ansible_3par_docker_plugin/tasks/deploy_FlexVolume_driver.yml
+++ b/ansible_3par_docker_plugin/tasks/deploy_FlexVolume_driver.yml
@@ -1,16 +1,23 @@
 ---
+  - name: load plugin settings
+    include_vars: 'properties/plugin_configuration_properties.yml'
+
+  - name: Initialize dory installer variable
+    set_fact:
+      dory_installer_version: "{{ INVENTORY['DEFAULT']['dory_installer_version'] }}"
+
   - name: Download dory installer
     get_url:
-      url: https://github.com/hpe-storage/python-hpedockerplugin/raw/master/dory_installer_v32
+      url: https://github.com/hpe-storage/python-hpedockerplugin/raw/master/{{dory_installer_version}}
       dest: /tmp 
       mode: 0755
 
   - name: Install dory, doryd
     shell: >-
-      yes yes | /tmp/dory_installer_v32
+      yes yes | /tmp/{{dory_installer_version}}
 
   - name: Remove the dory installer
     file:
-      path: /tmp/dory_installer_v32
+      path: /tmp/{{dory_installer_version}}
       state: absent
 

--- a/ansible_3par_docker_plugin/tasks/deploy_FlexVolume_driver.yml
+++ b/ansible_3par_docker_plugin/tasks/deploy_FlexVolume_driver.yml
@@ -1,16 +1,16 @@
 ---
   - name: Download dory installer
     get_url:
-      url: https://github.com/hpe-storage/python-hpedockerplugin/raw/master/dory_installer_v31
+      url: https://github.com/hpe-storage/python-hpedockerplugin/raw/master/dory_installer_v32
       dest: /tmp 
       mode: 0755
 
   - name: Install dory, doryd
     shell: >-
-      yes yes | /tmp/dory_installer_v31
+      yes yes | /tmp/dory_installer_v32
 
   - name: Remove the dory installer
     file:
-      path: /tmp/dory_installer_v31
+      path: /tmp/dory_installer_v32
       state: absent
 

--- a/docs/manual_install_guide_hpe_3par_plugin_with_openshift_kubernetes.md
+++ b/docs/manual_install_guide_hpe_3par_plugin_with_openshift_kubernetes.md
@@ -233,9 +233,9 @@ $ docker volume create -d hpe --name sample_vol -o size=
 
 10. Install the HPE 3PAR FlexVolume driver:
 ```
-$ wget https://github.com/hpe-storage/python-hpedockerplugin/raw/master/dory_installer_v31
-$ chmod u+x ./dory_installer_v31
-$ sudo ./dory_installer_v31
+$ wget https://github.com/hpe-storage/python-hpedockerplugin/raw/master/dory_installer_v32
+$ chmod u+x ./dory_installer_v32
+$ sudo ./dory_installer_v32
 ```
 
 11. Confirm HPE 3PAR FlexVolume driver installed correctly:


### PR DESCRIPTION
Hi William,
This is ansible installer change to install the dory v32 version as per the new requirement

Regards
Bhagyashree Sarawate