### PR TITLE
Fix manage usecases CI failures

### DIFF
--- a/hpedockerplugin/hpe/utils.py
+++ b/hpedockerplugin/hpe/utils.py
@@ -83,7 +83,7 @@ def _decode_name(name):
     name = name.replace('-', '/')
     name = name + "=="
 
-    vol_decoded = uuid.UUID(bytes=base64.decode_as_bytes(name))
+    vol_decoded = uuid.UUID(bytes=oslo_base64.decode_as_bytes(name))
     return str(vol_decoded)
 
 


### PR DESCRIPTION
```
2019-12-11 13:06:22,400 [ERROR] hpedockerplugin.volume_manager [140472599956360] MainThread Manage snapshot failed because parent volume: dcv-POFcQt0lT32ZqnjsSYZCTw is unmanaged.
2019-12-11 13:06:22.400 20 ERROR hpedockerplugin.volume_manager Traceback (most recent call last):
2019-12-11 13:06:22.400 20 ERROR hpedockerplugin.volume_manager   File "/python-hpedockerplugin/hpedockerplugin/volume_manager.py", line 427, in manage_existing
2019-12-11 13:06:22.400 20 ERROR hpedockerplugin.volume_manager     vol_id = utils.get_vol_id(existing_ref_details["copyOf"])
2019-12-11 13:06:22.400 20 ERROR hpedockerplugin.volume_manager   File "/python-hpedockerplugin/hpedockerplugin/hpe/utils.py", line 96, in get_vol_id
2019-12-11 13:06:22.400 20 ERROR hpedockerplugin.volume_manager     volume_id = _decode_name(volume_name)
2019-12-11 13:06:22.400 20 ERROR hpedockerplugin.volume_manager   File "/python-hpedockerplugin/hpedockerplugin/hpe/utils.py", line 86, in _decode_name
2019-12-11 13:06:22.400 20 ERROR hpedockerplugin.volume_manager     vol_decoded = uuid.UUID(bytes=base64.decode_as_bytes(name))
2019-12-11 13:06:22.400 20 ERROR hpedockerplugin.volume_manager AttributeError: module 'base64' has no attribute 'decode_as_bytes'
```